### PR TITLE
feat(ifl-891): fix create account to have correct chain head

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -202,7 +202,7 @@ export class IronFishManager implements IIronfishManager {
     await this.node.internal.save()
 
     this.assets = new AssetManager(this.node)
-    this.accounts = new AccountManager(this.node, this.assets)
+    this.accounts = new AccountManager(this.node, this.assets, this.sdk)
     this.transactions = new TransactionManager(this.node, this.assets)
     this.nodeSettings = new NodeSettingsManager(this.node)
     this.snapshot = new SnapshotManager(this.node)

--- a/src/data/DemoAccountsManager.ts
+++ b/src/data/DemoAccountsManager.ts
@@ -1,4 +1,4 @@
-import { AccountValue } from '@ironfish/sdk'
+import { AccountValue, CreateAccountResponse } from '@ironfish/sdk'
 import { nanoid } from 'nanoid'
 import randomWords from 'random-words'
 import AccountBalance from 'Types/AccountBalance'
@@ -225,7 +225,7 @@ class DemoAccountsManager implements IIronfishAccountManager {
     })
   }
 
-  create(name: string): Promise<AccountValue> {
+  create(name: string): Promise<CreateAccountResponse> {
     return new Promise(resolve => {
       setTimeout(() => {
         if (DEMO_ACCOUNTS.find(account => name === account.name)) {
@@ -260,7 +260,7 @@ class DemoAccountsManager implements IIronfishAccountManager {
           },
         ]
         this.onAccountCountChange()
-        resolve(account)
+        resolve({ ...account, isDefaultAccount: false })
       }, 500)
     })
   }
@@ -442,7 +442,9 @@ class DemoAccountsManager implements IIronfishAccountManager {
     }
   }
 
-  async submitAccount(createParams: AccountValue): Promise<Account> {
+  async submitAccount(
+    createParams: AccountValue
+  ): Promise<CreateAccountResponse> {
     return this.create(createParams.name)
   }
 }

--- a/types/IronfishManager/IIronfishAccountManager.ts
+++ b/types/IronfishManager/IIronfishAccountManager.ts
@@ -1,4 +1,8 @@
-import { AccountValue } from '@ironfish/sdk'
+import {
+  AccountValue,
+  CreateAccountResponse,
+  ImportResponse,
+} from '@ironfish/sdk'
 import AccountCreateParams from 'Types/AccountCreateParams'
 import Account from '../Account'
 import AccountBalance from '../AccountBalance'
@@ -28,7 +32,6 @@ export interface IIronfishAccountManager {
     default: AccountBalance
     assets: AccountBalance[]
   }>
-  create: (name: string) => Promise<Account>
   delete: (name: string) => Promise<void>
   export: (id: string, encoded?: boolean, viewOnly?: boolean) => Promise<string>
   get: (id: string) => Promise<Account>
@@ -39,5 +42,5 @@ export interface IIronfishAccountManager {
   isValidPublicAddress: (address: string) => Promise<boolean>
   list: (search?: string, sort?: SortType) => Promise<CutAccount[]>
   prepareAccount: () => Promise<AccountCreateParams>
-  submitAccount: (createParams: AccountValue) => Promise<Account>
+  submitAccount: (createParams: AccountValue) => Promise<ImportResponse>
 }


### PR DESCRIPTION
There is code in the RPC method for importing an account that is important for account initialization. Instead of calling methods directly from node, I use the RPC interface for importing account.

Create account test works, where account head is immediately moved to chain head:

https://github.com/iron-fish/node-app/assets/26990067/040dbc7c-2fb1-48eb-80c5-c47f0da3518b

Import account also works still with rescan occurring as expected:

<img width="1116" alt="Screen Shot 2023-05-09 at 1 52 32 PM" src="https://github.com/iron-fish/node-app/assets/26990067/ccb6b479-9ed0-4ec4-9884-a24bbff40f29">
