### PR TITLE
feat(ifl-911): add account syncing status and warnings

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -255,14 +255,13 @@ export class IronFishManager implements IIronfishManager {
     }
   }
 
-  nodeStatus(): Promise<NodeStatusResponse> {
+  async nodeStatus(): Promise<NodeStatusResponse> {
     if (
       this.initStatus < IronFishInitStatus.STARTED ||
       this.initStatus === IronFishInitStatus.ERROR
     ) {
       return Promise.resolve(null)
     }
-
     let totalSequences = 0
     const peers = this.node.peerNetwork.peerManager
       .getConnectedPeers()
@@ -271,6 +270,10 @@ export class IronFishManager implements IIronfishManager {
     if (peers.length > 0) {
       totalSequences = peers[0].sequence
     }
+    const client = await this.sdk.connectRpc()
+    const accounts = (await client.wallet.getAccountsStatus({})).content
+      .accounts
+
     const status = {
       node: {
         status: this.node.started
@@ -322,6 +325,7 @@ export class IronFishManager implements IIronfishManager {
         headTimestamp: this.node.chain.head.timestamp.getTime(),
         newBlockSpeed: this.node.metrics.chain_newBlock.avg,
       },
+      accounts: accounts,
     }
     return Promise.resolve(status)
   }

--- a/src/components/Navbar/StatusBar/NodeSyncStatus.tsx
+++ b/src/components/Navbar/StatusBar/NodeSyncStatus.tsx
@@ -70,39 +70,62 @@ const renderTime = (time: number) => {
   return result.reverse().join(' ')
 }
 
-const NodeSyncStatus: FC<DataSyncContextProps> = ({ data, synced }) => (
-  <>
-    <chakra.h5 color="inherit">
-      Node Status:{' '}
-      {getNodeSyncStatus(
-        data?.blockSyncer.status,
-        data?.blockSyncer?.syncing?.progress,
-        data?.peerNetwork?.isReady && data?.peerNetwork?.peers > 0
-      )}
-    </chakra.h5>
-    {!synced &&
-      data?.peerNetwork?.isReady &&
-      data?.peerNetwork?.peers > 0 &&
-      data?.blockSyncer.status === 'syncing' && (
-        <>
-          <chakra.h5 color="inherit">
-            {`${(data?.blockSyncer.syncing.progress * 100).toFixed(2)}%`}
-            {' | '}
-            {`${renderTime(
-              (Number(data?.blockchain?.totalSequences || 0) -
-                Number(data?.blockchain?.head || 0)) /
-                (data?.blockSyncer?.syncing?.speed || 1)
-            )}`}
-          </chakra.h5>
-          <chakra.h5 color="inherit">
-            {`${data?.blockchain.head}`}
-            {' / '}
-            {`${data?.blockchain.totalSequences}`}
-            {' blocks'}
-          </chakra.h5>
-        </>
-      )}
-  </>
-)
+const NodeSyncStatus: FC<DataSyncContextProps> = ({ data, synced }) => {
+  const leastSyncedAccount = data?.accounts?.reduce((prev, current) =>
+    !Number.isNaN(+current.sequence) &&
+    Number(current.sequence) < Number(data?.blockchain.head) &&
+    current.sequence < prev.sequence
+      ? current
+      : prev
+  )
+  return (
+    <>
+      <chakra.h5 color="inherit">
+        Node Status:{' '}
+        {getNodeSyncStatus(
+          data?.blockSyncer.status,
+          data?.blockSyncer?.syncing?.progress,
+          data?.peerNetwork?.isReady && data?.peerNetwork?.peers > 0
+        )}
+      </chakra.h5>
+      {!synced &&
+        data?.peerNetwork?.isReady &&
+        data?.peerNetwork?.peers > 0 &&
+        data?.blockSyncer.status === 'syncing' && (
+          <>
+            <chakra.h5 color="inherit">
+              {`${(data?.blockSyncer.syncing.progress * 100).toFixed(2)}%`}
+              {' | '}
+              {`${renderTime(
+                (Number(data?.blockchain?.totalSequences || 0) -
+                  Number(data?.blockchain?.head || 0)) /
+                  (data?.blockSyncer?.syncing?.speed || 1)
+              )}`}
+            </chakra.h5>
+            <chakra.h5 color="inherit">
+              {`${data?.blockchain.head}`}
+              {' / '}
+              {`${data?.blockchain.totalSequences}`}
+              {' blocks'}
+            </chakra.h5>
+          </>
+        )}
+      {synced &&
+        leastSyncedAccount &&
+        Number(leastSyncedAccount.sequence) <
+          Number(data?.blockchain.head) - 2 && (
+          <>
+            <chakra.h5 color="inherit">
+              {`Account ${leastSyncedAccount.name} syncing: ${(
+                ((Number(leastSyncedAccount.sequence) * 1.0) /
+                  Number(data?.blockchain.head)) *
+                100
+              ).toFixed(2)}%`}
+            </chakra.h5>
+          </>
+        )}
+    </>
+  )
+}
 
 export default NodeSyncStatus

--- a/src/components/Navbar/StatusBar/StatusItem.tsx
+++ b/src/components/Navbar/StatusBar/StatusItem.tsx
@@ -104,7 +104,6 @@ export const StatusItem: FC<StatusItemProps> = ({
   ...props
 }) => {
   const small = useBreakpointValue({ base: true, sm: false })
-
   return (
     <Tooltip
       label={

--- a/src/components/Navbar/StatusBar/index.tsx
+++ b/src/components/Navbar/StatusBar/index.tsx
@@ -16,7 +16,7 @@ import { StatusItem } from './StatusItem'
 import NodeSyncStatus from './NodeSyncStatus'
 
 const ActiveStatus: FC<FlexProps> = props => {
-  const { synced, data, requiredSnapshot, sync } = useDataSync()
+  const { synced, accountsSynced, data, requiredSnapshot, sync } = useDataSync()
   const { status } = useSnapshotStatus()
   const small = useBreakpointValue({ base: true, sm: false })
   const download = useMemo(
@@ -25,7 +25,6 @@ const ActiveStatus: FC<FlexProps> = props => {
       status?.status < SnapshotProgressStatus.COMPLETED,
     [status?.status]
   )
-
   return (
     <Flex
       my={{ base: 0, sm: '1rem' }}
@@ -56,7 +55,7 @@ const ActiveStatus: FC<FlexProps> = props => {
       </StatusItem>
       <StatusItem
         display={requiredSnapshot || download ? 'none' : 'flex'}
-        style={synced ? 'default' : 'warning'}
+        style={synced && accountsSynced ? 'default' : 'warning'}
       >
         {isMinified =>
           isMinified ? (

--- a/src/components/SyncWarningMessage.tsx
+++ b/src/components/SyncWarningMessage.tsx
@@ -7,14 +7,13 @@ interface SyncWarningMessageProps extends FlexProps {
 }
 
 const SyncWarningMessage: FC<SyncWarningMessageProps> = ({
-  message = 'Your account balance might not be accurate while you’re syncing to the blockchain',
+  message = 'Your account balance might not be accurate while you’re syncing',
   ...rest
 }) => {
-  const { synced } = useDataSync()
-
+  const { synced, accountsSynced } = useDataSync()
   return (
     <Flex
-      display={synced ? 'none' : 'flex'}
+      display={synced && accountsSynced ? 'none' : 'flex'}
       borderRadius="0.3125rem"
       bg={'#FFF9BC'}
       _dark={{

--- a/types/NodeStatusResponse.ts
+++ b/types/NodeStatusResponse.ts
@@ -44,6 +44,13 @@ export type NodeStatusResponse = Partial<{
       ours: string
     }>
   }>
+  accounts: Partial<{
+    name: string
+    id: string
+    headHash: string
+    headInChain: boolean
+    sequence: string | number
+  }>[]
 }>
 
 export default NodeStatusResponse


### PR DESCRIPTION
This PR does three things:

1. Returns account info in the status request to the node
2. Updates the Warning message to display when either the chain isn't synced OR an account isn't synced. This is the lowest code change method of handling this functionality.
3.  Updates the general syncing tab to display syncing info when imported accounts are being synced.

We can split these into separate PRs if the code change is too much.

<img width="1160" alt="Screenshot 2023-05-17 at 3 21 41 PM" src="https://github.com/iron-fish/node-app/assets/26990067/4e58e01f-5a7f-445c-a504-2cf2dfb621fb">

