### PR TITLE
feat(ifl-900): updates transaction view for outputs to show owner instead of sender

### DIFF
--- a/electron/ironfish/TransactionManager.ts
+++ b/electron/ironfish/TransactionManager.ts
@@ -124,6 +124,7 @@ class TransactionManager
           memo: n.note.memo(),
           sender: n.note.sender(),
           asset: await this.assetManager.get(n.note.assetId()),
+          owner: n.note.owner(),
         }))
       ),
       outputs: serializedNotes,

--- a/src/data/DemoTransactionsManager.ts
+++ b/src/data/DemoTransactionsManager.ts
@@ -31,6 +31,9 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         memo: 'For my friend',
         sender:
           'EuERI13A6py2GYSdcx4OA96X0DL8uSLh5VnqpTqwCGVmgn40GWutuMegDKfI53Zk',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
+
         asset: DEFAULT_ASSET,
       },
     ],
@@ -40,6 +43,19 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         memo: 'dziakyi',
         sender:
           'EuERI13A6py2GYSdcx4OA96X0DL8uSLh5VnqpTqwCGVmgn40GWutuMegDKfI53Zk',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
+
+        asset: DEFAULT_ASSET,
+      },
+      {
+        value: BigInt(10000),
+        memo: 'to you',
+        sender:
+          'EuERI13A6py2GYSdcx4OA96X0DL8uSLh5VnqpTqwCGVmgn40GWutuMegDKfI53Zk',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
+
         asset: DEFAULT_ASSET,
       },
       {
@@ -48,13 +64,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'EuERI13A6py2GYSdcx4OA96X0DL8uSLh5VnqpTqwCGVmgn40GWutuMegDKfI53Zk',
         asset: DEFAULT_ASSET,
-      },
-      {
-        value: BigInt(10000),
-        memo: 'to you',
-        sender:
-          'EuERI13A6py2GYSdcx4OA96X0DL8uSLh5VnqpTqwCGVmgn40GWutuMegDKfI53Zk',
-        asset: DEFAULT_ASSET,
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
     ],
     spends: [
@@ -95,6 +106,9 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         memo: 'thanks',
         sender:
           'hCXJwl8cB-pk3sqnxp5op_dgVMWce2vYdr6PT7bdN03gKLt6fWJd2Mxks-vWbhC7',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
+
         asset: DEFAULT_ASSET,
       },
       {
@@ -103,6 +117,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         memo: 'asset to you',
         sender:
           'hCXJwl8cB-pk3sqnxp5op_dgVMWce2vYdr6PT7bdN03gKLt6fWJd2Mxks-vWbhC7',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
     ],
     spends: [],
@@ -133,6 +149,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'sbVxDJmJHGSKCfom0i33HRPFQvRY4t55ZVSSUwPuhRZcbIvJ0ou4hPHKv3HtGmOi',
         asset: DEFAULT_ASSET,
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
     ],
     spends: [],
@@ -171,6 +189,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         memo: 'Experimental',
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
       {
         value: BigInt(8256000000),
@@ -178,6 +198,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         memo: 'My demo asset',
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
       {
         value: BigInt(9673000000),
@@ -185,6 +207,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         memo: 'My test asset',
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
     ],
     outputs: [
@@ -194,6 +218,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
         asset: DEFAULT_ASSET,
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
       {
         value: BigInt(154000000),
@@ -201,6 +227,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
         asset: DEMO_ASSETS[1],
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
       {
         value: BigInt(297000000),
@@ -208,6 +236,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
         asset: DEMO_ASSETS[2],
+        owner:
+          'R3R4wctME31FBxi8HKo3PDhSYXMkknX_vPAe6gY7eC1gUZww6O9Bif2swAxj8sE6',
       },
     ],
     spends: [
@@ -243,6 +273,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
         asset: DEFAULT_ASSET,
+        owner:
+          '7C5NxoCyjt86wtEEHEF1d60omCsaH9tFO6Tf6Rn0jqowxowgbBtCoapcSxn0jrXN',
       },
     ],
     outputs: [
@@ -252,6 +284,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'pjqETg9UDzCmE9QSuWwrNO80NC9GNYtLWwyHhw0slynI1lRi9NS3BX_sD8yWtk7D',
         asset: DEFAULT_ASSET,
+        owner:
+          '7C5NxoCyjt86wtEEHEF1d60omCsaH9tFO6Tf6Rn0jqowxowgbBtCoapcSxn0jrXN',
       },
     ],
     spends: [
@@ -288,6 +322,8 @@ const DEMO_TRANSACTIONS: Transaction[] = [
         sender:
           'OOlgJpCs_om-pVc7vhew3R58cfI5N0Stn4KKZNOVmx2tSN-2wHZTMqFqtL9ackOV',
         asset: DEFAULT_ASSET,
+        owner:
+          '7C5NxoCyjt86wtEEHEF1d60omCsaH9tFO6Tf6Rn0jqowxowgbBtCoapcSxn0jrXN',
       },
     ],
     spends: [],
@@ -423,6 +459,7 @@ class DemoTransactionsManager implements IIronfishTransactionManager {
               memo: memo,
               sender: publicAddress,
               asset: DEFAULT_ASSET,
+              owner: publicAddress,
             },
           ],
           outputs: [
@@ -431,6 +468,7 @@ class DemoTransactionsManager implements IIronfishTransactionManager {
               memo: memo,
               sender: accountId,
               asset: DEFAULT_ASSET,
+              owner: publicAddress,
             },
           ],
           spends: [],

--- a/src/routes/Transaction/TransactionOverview.tsx
+++ b/src/routes/Transaction/TransactionOverview.tsx
@@ -381,7 +381,7 @@ const TransactionOverview: FC = () => {
                       <LargeArrowRightUp h="1.125rem" w="1.125rem" />
                     </Box>
                     <chakra.h5>
-                      <ContactsPreview addresses={[note?.sender]} />
+                      <ContactsPreview addresses={[note?.owner]} />
                     </chakra.h5>
                   </Flex>
                 ),

--- a/types/Transaction.ts
+++ b/types/Transaction.ts
@@ -5,6 +5,7 @@ export interface Note {
   memo: string
   sender: string
   asset: Asset
+  owner: string
 }
 
 export interface Spend {


### PR DESCRIPTION
Before:
<img width="1227" alt="Screen Shot 2023-05-10 at 2 02 26 PM" src="https://github.com/iron-fish/node-app/assets/26990067/f2942a42-e81b-4d51-a894-abd1ba0119e6">


After:

<img width="1169" alt="Screen Shot 2023-05-10 at 1 57 54 PM" src="https://github.com/iron-fish/node-app/assets/26990067/4ed5bfd9-edcb-4168-a16c-af07a10f3661">
