### PR TITLE
fix: DataSyncProvider exeception fix

### DIFF
--- a/src/providers/DataSyncProvider.tsx
+++ b/src/providers/DataSyncProvider.tsx
@@ -53,6 +53,10 @@ const DataSyncProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const loadStatus = () =>
     window.IronfishManager.nodeStatus()
       .then(nextStatus => {
+        if (!nextStatus) {
+          return
+        }
+
         setNodeStatus(prevStatus => {
           let nextTotalSequences = nextStatus.blockchain.totalSequences
           if (


### PR DESCRIPTION
During app onboarding, this was throwing an exception because node is not started and therefore no status can be retrieved.