### PR TITLE
(IFL-925) Use select box for node workers in settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,8 @@ typings/
 out/
 dist/
 
+# signing certificates
+.certs
+
 #vscode
 .vscode/

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@aws-sdk/client-s3": "3.127.0",
     "@ironfish/rust-nodejs": "1.0.0",
     "@ironfish/sdk": "1.1.0",
-    "@ironfish/ui-kit": "1.1.8",
+    "@ironfish/ui-kit": "1.1.10",
     "@types/nedb": "^1.8.12",
     "bech32": "^2.0.0",
     "date-fns": "^2.28.0",

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -5,9 +5,8 @@ import {
   InputProps as InputPropsType,
   StyleProps,
   TextField,
+  IconBlinkingEye,
 } from '@ironfish/ui-kit'
-import IconBlinkingEye from '@ironfish/ui-kit/dist/svgx/icon-blinkingEye'
-import IconInfo from '@ironfish/ui-kit/dist/svgx/icon-info'
 import debounce from 'lodash/debounce'
 
 interface PasswordFieldProps extends StyleProps {

--- a/src/components/Search&Sort/SortSelect.tsx
+++ b/src/components/Search&Sort/SortSelect.tsx
@@ -4,9 +4,9 @@ import {
   SelectField,
   useBreakpointValue,
   Flex,
+  ArrowUpArrowDownIcon,
 } from '@ironfish/ui-kit'
 import { OptionType } from '@ironfish/ui-kit/dist/components/SelectField'
-import ArrowUpArrowDownIcon from '@ironfish/ui-kit/dist/svgx/arrow-up-arrow-down-icon'
 
 //TODO: Need add export of type in ui-kit lib
 export interface SelectFieldProps extends FlexProps {

--- a/src/components/TransactionStatusView.tsx
+++ b/src/components/TransactionStatusView.tsx
@@ -5,10 +5,10 @@ import {
   useColorModeValue,
   chakra,
   IconProps,
+  PendingIcon,
+  ExpiredIcon,
 } from '@ironfish/ui-kit'
 import { TransactionStatus } from 'Types/Transaction'
-import PendingIcon from '@ironfish/ui-kit/dist/svgx/pending-icon'
-import ExpiredIcon from '@ironfish/ui-kit/dist/svgx/expired-icon'
 import IconSend from 'Svgx/send'
 import IconReceive from 'Svgx/receive'
 

--- a/src/hooks/node/useNodeStatus.ts
+++ b/src/hooks/node/useNodeStatus.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import NodeStatusResponse from 'Types/NodeStatusResponse'
 
-const useNodeStatus = () => {
+const useNodeStatus = (pauseTracking = false) => {
   const [loaded, setLoaded] = useState<boolean>(false)
   const [status, setNodeStatus] = useState<NodeStatusResponse | undefined>()
   const [error, setError] = useState()
@@ -14,11 +14,14 @@ const useNodeStatus = () => {
   }
 
   useEffect(() => {
-    const infinite = setInterval(() => {
-      loadStatus()
-    }, 1000)
-    return () => clearInterval(infinite)
-  }, [])
+    let infinite: NodeJS.Timer
+    if (!pauseTracking) {
+      infinite = setInterval(() => {
+        loadStatus()
+      }, 1000)
+    }
+    return () => infinite && clearInterval(infinite)
+  }, [pauseTracking])
 
   return {
     loaded,

--- a/src/routes/Accounts/AccountTabs/Keys.tsx
+++ b/src/routes/Accounts/AccountTabs/Keys.tsx
@@ -8,12 +8,12 @@ import {
   MnemonicView,
   CopyToClipboardButton,
   SelectField,
+  DownloadIcon,
 } from '@ironfish/ui-kit'
 import DetailsPanel from 'Components/DetailsPanel'
 import { FC, memo, useState } from 'react'
 import AccountKeysImage from 'Svgx/AccountKeysImage'
 import LinkLaunchIcon from 'Svgx/LinkLaunch'
-import DownloadIcon from '@ironfish/ui-kit/dist/svgx/download-icon'
 import Account from 'Types/Account'
 import useMnemonicPhrase from 'Hooks/accounts/useMnemonicPhrase'
 import { OptionType } from '@ironfish/ui-kit/dist/components/SelectField'

--- a/src/routes/Accounts/Accounts.tsx
+++ b/src/routes/Accounts/Accounts.tsx
@@ -8,8 +8,8 @@ import {
   useBreakpointValue,
   ButtonsGroup,
   Skeleton,
+  IconAdd,
 } from '@ironfish/ui-kit'
-import IconAdd from '@ironfish/ui-kit/dist/svgx/icon-add'
 import SearchSortField from 'Components/Search&Sort'
 import useAccounts from 'Hooks/accounts/useAccounts'
 import AccountPreview from 'Routes/Accounts/AccountPreview'

--- a/src/routes/AddressBook/AddressBook.tsx
+++ b/src/routes/AddressBook/AddressBook.tsx
@@ -9,8 +9,8 @@ import {
   CopyValueToClipboard,
   useBreakpointValue,
   useIronToast,
+  IconAdd,
 } from '@ironfish/ui-kit'
-import IconAdd from '@ironfish/ui-kit/dist/svgx/icon-add'
 import SendIcon from 'Svgx/send'
 import HexFishCircle from 'Components/HexFishCircle'
 import { truncateHash } from 'Utils/hash'

--- a/src/routes/NodeOverview/NodeOverview.tsx
+++ b/src/routes/NodeOverview/NodeOverview.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import {
   chakra,
   TabPanels,
@@ -11,14 +11,13 @@ import NodeStatus from './NodeStatus'
 import NodePeers from './NodePeers'
 import NodeSettings from './NodeSettings'
 import NodeResources from './NodeResources'
-import useNodeStatus from 'Hooks/node/useNodeStatus'
 
 const NodeOverview: FC = () => {
-  const { loaded, data, error } = useNodeStatus()
+  const [tabIndex, setTabIndex] = useState(0)
   return (
     <>
       <chakra.h2 mb="1rem">Your Node</chakra.h2>
-      <Tabs>
+      <Tabs onChange={index => setTabIndex(index)}>
         <TabList>
           <Tab>
             <h6>Node Overview</h6>
@@ -32,7 +31,7 @@ const NodeOverview: FC = () => {
         </TabList>
         <TabPanels>
           <TabPanel p="0" pt="2rem">
-            <NodeStatus mb="2rem" data={data} loaded={loaded} />
+            <NodeStatus mb="2rem" pauseTracking={tabIndex !== 0} />
             <chakra.h3>Connected Peers</chakra.h3>
             <NodePeers />
           </TabPanel>
@@ -40,7 +39,7 @@ const NodeOverview: FC = () => {
             <NodeSettings />
           </TabPanel>
           <TabPanel p="0" pt="2rem">
-            <NodeResources data={data} loaded={loaded} />
+            <NodeResources pauseTracking={tabIndex !== 2} />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/routes/NodeOverview/NodeResources.tsx
+++ b/src/routes/NodeOverview/NodeResources.tsx
@@ -9,6 +9,7 @@ import {
 } from '@ironfish/ui-kit'
 import { FileUtils } from '@ironfish/sdk/build/src/utils/file'
 import NodeStatusResponse from 'Types/NodeStatusResponse'
+import useNodeStatus from 'Hooks/node/useNodeStatus'
 
 interface NodeResourceProps {
   label: ReactNode
@@ -26,12 +27,8 @@ const NodeResource: FC<NodeResourceProps> = ({ label, value }) => (
   </Stat>
 )
 
-interface NodeResourcesProps {
-  data: NodeStatusResponse
-  loaded: boolean
-}
-
-const NodeResources: FC<NodeResourcesProps> = ({ data, loaded }) => {
+const NodeResources: FC<{ pauseTracking: boolean }> = ({ pauseTracking }) => {
+  const { loaded, data, error } = useNodeStatus(pauseTracking)
   const heapTotal = FileUtils.formatMemorySize(data?.memory.heapTotal)
   const heapUsed = FileUtils.formatMemorySize(data?.memory.heapUsed)
   const heapMax = FileUtils.formatMemorySize(data?.memory.heapMax)

--- a/src/routes/NodeOverview/NodeSettings.tsx
+++ b/src/routes/NodeOverview/NodeSettings.tsx
@@ -8,6 +8,7 @@ import {
   useIronToast,
   Box,
   NAMED_COLORS,
+  Grid,
 } from '@ironfish/ui-kit'
 import useNodeSettings from 'Hooks/node/useNodeSettings'
 import { FC, useState, useEffect, memo, useMemo } from 'react'
@@ -82,9 +83,14 @@ const NodeSettings: FC = () => {
 
   return (
     <Flex>
-      <Flex direction="column" w="37.25rem">
-        <Flex gap="2rem">
-          <Skeleton w="50%" my="1rem" variant="ironFish" isLoaded={!!data}>
+      <Flex display="column">
+        <Grid
+          w="37.25rem"
+          templateColumns="repeat(2, 1fr)"
+          gridAutoRows={'auto'}
+          gap="2rem"
+        >
+          <Skeleton variant="ironFish" isLoaded={!!data}>
             <TextField
               label="Node name"
               value={nodeSettings?.nodeName}
@@ -93,7 +99,7 @@ const NodeSettings: FC = () => {
               }}
             />
           </Skeleton>
-          <Skeleton w="50%" my="1rem" variant="ironFish" isLoaded={!!data}>
+          <Skeleton variant="ironFish" isLoaded={!!data}>
             <TextField
               label="Block graffiti"
               value={nodeSettings?.blockGraffiti}
@@ -103,31 +109,27 @@ const NodeSettings: FC = () => {
               }}
             />
           </Skeleton>
-        </Flex>
-        <Skeleton my="1rem" variant="ironFish" isLoaded={!!data}>
-          <Flex gap="2rem">
+          <Skeleton variant="ironFish" isLoaded={!!data}>
             <TextField
               label="Min Peers"
-              w="50%"
               value={nodeSettings?.minPeers?.toString()}
               InputProps={{
                 type: 'number',
                 onChange: e => updateSettingValue('minPeers', e.target.value),
               }}
             />
+          </Skeleton>
+          <Skeleton variant="ironFish" isLoaded={!!data}>
             <TextField
               label="Max peers"
-              w="50%"
               value={nodeSettings?.maxPeers?.toString()}
               InputProps={{
                 type: 'number',
                 onChange: e => updateSettingValue('maxPeers', e.target.value),
               }}
             />
-          </Flex>
-        </Skeleton>
-        <Flex gap="2rem">
-          <Skeleton w="50%" my="1rem" variant="ironFish" isLoaded={!!data}>
+          </Skeleton>
+          <Skeleton variant="ironFish" isLoaded={!!data}>
             <TextField
               label="Node workers"
               value={nodeSettings?.nodeWorkers?.toString()}
@@ -138,7 +140,7 @@ const NodeSettings: FC = () => {
               }}
             />
           </Skeleton>
-          <Skeleton w="50%" variant="ironFish" my="1rem" isLoaded={!!data}>
+          <Skeleton variant="ironFish" isLoaded={!!data}>
             <TextField
               label="Blocks Per Message"
               value={nodeSettings?.blocksPerMessage?.toString()}
@@ -149,17 +151,16 @@ const NodeSettings: FC = () => {
               }}
             />
           </Skeleton>
-        </Flex>
-        <Flex my="1rem" gap="32px">
-          <Button
-            variant="primary"
-            size="large"
-            onClick={handleSaveSettings}
-            isDisabled={!loaded || hasNoChanges}
-          >
-            Save settings
-          </Button>
-        </Flex>
+        </Grid>
+        <Button
+          mt="2rem"
+          variant="primary"
+          size="large"
+          onClick={handleSaveSettings}
+          isDisabled={!loaded || hasNoChanges}
+        >
+          Save settings
+        </Button>
       </Flex>
       <Box>
         <DetailsPanel>

--- a/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
+++ b/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
@@ -15,6 +15,7 @@ import { FC, useState, useEffect, memo, useMemo } from 'react'
 import pick from 'lodash/pick'
 import DetailsPanel from 'Components/DetailsPanel'
 import AccountSettingsImage from 'Svgx/AccountSettingsImage'
+import NodeWorkersSelect from './NodeWorkersSelect'
 
 const Information: FC = memo(() => {
   return (
@@ -130,7 +131,13 @@ const NodeSettings: FC = () => {
             />
           </Skeleton>
           <Skeleton variant="ironFish" isLoaded={!!data}>
-            <TextField
+            <NodeWorkersSelect
+              value={nodeSettings?.nodeWorkers?.toString()}
+              onSelectOption={selected =>
+                updateSettingValue('nodeWorkers', selected.value)
+              }
+            />
+            {/* <TextField
               label="Node workers"
               value={nodeSettings?.nodeWorkers?.toString()}
               InputProps={{
@@ -138,7 +145,7 @@ const NodeSettings: FC = () => {
                 onChange: e =>
                   updateSettingValue('nodeWorkers', e.target.value),
               }}
-            />
+            /> */}
           </Skeleton>
           <Skeleton variant="ironFish" isLoaded={!!data}>
             <TextField

--- a/src/routes/NodeOverview/NodeSettings/NodeWorkersSelect.tsx
+++ b/src/routes/NodeOverview/NodeSettings/NodeWorkersSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useMemo } from 'react'
+import { FC, ReactNode, useMemo, useState } from 'react'
 import { SelectField, Flex, Box, Tooltip } from '@ironfish/ui-kit'
 import { OptionType } from '@ironfish/ui-kit/dist/components/SelectField'
 
@@ -26,6 +26,7 @@ const NodeWorkersSelect: FC<NodeWorkersSelectProps> = ({
   value,
   onSelectOption,
 }) => {
+  const [showTooltip, setShowTooltip] = useState(false)
   const selectOptions = useMemo(() => {
     let options = [...new Array(window.navigator.hardwareConcurrency || 0)]
     options = [
@@ -49,6 +50,7 @@ const NodeWorkersSelect: FC<NodeWorkersSelectProps> = ({
 
   return (
     <Tooltip
+      isOpen={showTooltip}
       label={
         'The number of CPU workers to use for long-running node operations, \
          like creating transactions and verifying blocks. 0 disables workers \
@@ -67,6 +69,8 @@ const NodeWorkersSelect: FC<NodeWorkersSelectProps> = ({
           label="Node workers"
           renderOption={option => <Option label={option.label} />}
           maxMenuHeight={220}
+          onMouseEnter={() => setShowTooltip(true)}
+          onMouseLeave={() => setShowTooltip(false)}
         />
       </Box>
     </Tooltip>

--- a/src/routes/NodeOverview/NodeSettings/NodeWorkersSelect.tsx
+++ b/src/routes/NodeOverview/NodeSettings/NodeWorkersSelect.tsx
@@ -1,0 +1,75 @@
+import { FC, ReactNode, useMemo } from 'react'
+import { SelectField, Flex, Box, Tooltip } from '@ironfish/ui-kit'
+import { OptionType } from '@ironfish/ui-kit/dist/components/SelectField'
+
+const Option: FC<{ label: ReactNode }> = ({ label }) => {
+  return (
+    <Flex
+      p="0.375rem 1rem"
+      minH="1.875rem"
+      alignItems="center"
+      cursor="pointer"
+    >
+      <Box overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+        {label}
+      </Box>
+    </Flex>
+  )
+}
+
+interface NodeWorkersSelectProps {
+  onSelectOption?: (option: OptionType) => void
+  value: string
+}
+
+const NodeWorkersSelect: FC<NodeWorkersSelectProps> = ({
+  value,
+  onSelectOption,
+}) => {
+  const selectOptions = useMemo(() => {
+    let options = [...new Array(window.navigator.hardwareConcurrency || 0)]
+    options = [
+      {
+        value: -1,
+        label: 'Auto-detect',
+      },
+      {
+        value: 0,
+        label: 'Disable',
+      },
+    ].concat(
+      ...options.map((_, index) => ({
+        value: index + 1,
+        label: (index + 1).toString(),
+      }))
+    )
+
+    return options
+  }, [])
+
+  return (
+    <Tooltip
+      label={
+        'The number of CPU workers to use for long-running node operations, \
+         like creating transactions and verifying blocks. 0 disables workers \
+          (this is likely to cause performance issues), and -1 auto-detects \
+           based on the number of CPU cores. Each worker uses several hundred \
+            MB of memory, so try a lower value to reduce memory consumption.'
+      }
+      placement="top"
+    >
+      <Box>
+        <SelectField
+          h="69px"
+          value={selectOptions.find(option => option?.value === Number(value))}
+          onSelectOption={onSelectOption}
+          options={selectOptions}
+          label="Node workers"
+          renderOption={option => <Option label={option.label} />}
+        />
+      </Box>
+    </Tooltip>
+  )
+}
+
+export default NodeWorkersSelect

--- a/src/routes/NodeOverview/NodeSettings/NodeWorkersSelect.tsx
+++ b/src/routes/NodeOverview/NodeSettings/NodeWorkersSelect.tsx
@@ -66,6 +66,7 @@ const NodeWorkersSelect: FC<NodeWorkersSelectProps> = ({
           options={selectOptions}
           label="Node workers"
           renderOption={option => <Option label={option.label} />}
+          maxMenuHeight={220}
         />
       </Box>
     </Tooltip>

--- a/src/routes/NodeOverview/NodeSettings/index.tsx
+++ b/src/routes/NodeOverview/NodeSettings/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './NodeSettings'

--- a/src/routes/NodeOverview/NodeStatus.tsx
+++ b/src/routes/NodeOverview/NodeStatus.tsx
@@ -16,6 +16,7 @@ import {
 import NodeOverviewImage from 'Svgx/NodeOverviewImage'
 import { FileUtils } from '@ironfish/sdk/build/src/utils/file'
 import NodeStatusResponse from 'Types/NodeStatusResponse'
+import useNodeStatus from 'Hooks/node/useNodeStatus'
 
 interface NodeStatProps {
   isLoaded: boolean
@@ -43,11 +44,12 @@ const NodeStat: FC<NodeStatProps> = ({ isLoaded, label, value }) => (
 )
 
 interface NodeStatusProps extends BoxProps {
-  data: NodeStatusResponse
-  loaded: boolean
+  pauseTracking: boolean
 }
 
-const NodeStatus: FC<NodeStatusProps> = ({ data, loaded, ...props }) => {
+const NodeStatus: FC<NodeStatusProps> = ({ pauseTracking, ...props }) => {
+  const { loaded, data, error } = useNodeStatus(pauseTracking)
+
   return (
     <Box
       p="4rem"

--- a/src/routes/Receive/ReceiveMoney.tsx
+++ b/src/routes/Receive/ReceiveMoney.tsx
@@ -8,15 +8,15 @@ import {
   TextField,
   FieldGroup,
   Tooltip,
+  IconCopy,
+  CheckIcon,
 } from '@ironfish/ui-kit'
 import { useLocation } from 'react-router-dom'
 import DetailsPanel from 'Components/DetailsPanel'
 import ReceiveIronImage from 'Svgx/ReceiveIronImage'
 import LinkLaunchIcon from 'Svgx/LinkLaunch'
-import IconCopy from '@ironfish/ui-kit/dist/svgx/icon-copy'
 import LocationStateProps from 'Types/LocationState'
 import AccountsSelect from 'Components/AccountsSelect'
-import IconCheck from '@ironfish/ui-kit/dist/svgx/icon-check'
 import CutAccount from 'Types/CutAccount'
 
 const Information: FC = memo(() => {
@@ -102,7 +102,7 @@ const ViewField: FC<ViewFieldProps> = ({
         >
           <Flex align="center">
             <chakra.h4 mr="8px">{buttonText}</chakra.h4>
-            {$copied ? <IconCheck color="green" /> : <IconCopy />}
+            {$copied ? <CheckIcon color="green" /> : <IconCopy />}
           </Flex>
         </Tooltip>
       </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3531,10 +3531,10 @@
     ws "8.12.1"
     yup "0.29.3"
 
-"@ironfish/ui-kit@1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@ironfish/ui-kit/-/ui-kit-1.1.8.tgz#9a434d47ef3f69e0003e9e79be23ffb887004e75"
-  integrity sha512-wQthr+CJCBMQ8Z78UTC9kDhyLhlTj7Pj9hsA2ftPIkc/WOGBrgWLDYm/Al/yljASepDNPNduXxSRIisKH2AxlQ==
+"@ironfish/ui-kit@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.npmjs.org/@ironfish/ui-kit/-/ui-kit-1.1.10.tgz#81b5cc74cd95657a0817fd5547d61a61229b2aa4"
+  integrity sha512-+WNuq5Ee/Z/+EKsuHrgGUx7hkEW1SI2YTl+sAGaDLYqGuey8IjQzLaxndFjiI2wGMJ+zQyhJPtRYoYy/uH/dvg==
   dependencies:
     "@chakra-ui/icons" "2.0.17"
     "@chakra-ui/react" "2.5.1"


### PR DESCRIPTION
Made node settings page use grid for items layout.
Use select for node workers.
Added tooltip for node workers with message from sdk source.
Default value is still -1 but now its displayed as `auto-detect`.

<img width="1110" alt="Screenshot 2023-05-25 at 2 27 29 PM" src="https://github.com/iron-fish/node-app/assets/3639170/68d41b77-1e62-482b-b3a5-bee187b0bf7f">
<img width="936" alt="Screenshot 2023-05-25 at 2 27 35 PM" src="https://github.com/iron-fish/node-app/assets/3639170/becef654-3ec9-4b05-9065-418bc06171b9">
