### PR TITLE
feat(ifl-994): account birthday on creation for better onboarding

### DIFF
--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -271,7 +271,13 @@ class AccountManager
 
   async prepareAccount(): Promise<AccountCreateParams> {
     const key = generateKey()
-
+    const createdAt =
+      this.node.chain.head.sequence > 1
+        ? {
+            sequence: this.node.chain.head.sequence,
+            hash: this.node.chain.head.hash,
+          }
+        : null
     return {
       version: ACCOUNT_SCHEMA_VERSION,
       id: uuid(),
@@ -281,7 +287,7 @@ class AccountManager
       publicAddress: key.publicAddress,
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
-      createdAt: null,
+      createdAt,
       mnemonicPhrase: spendingKeyToWords(
         key.spendingKey,
         LanguageCode.English


### PR DESCRIPTION
Previously, if you onboarded to ironfish via node-app, the account birthday of the newly created account is null, meaning the entire chain has to be rescanned to show up to date status.

This handles that issue, it also uses the local chain head if syncing if chain has already occurred.

Defaults on any issue to `createdAt=null` meaning chain scan will occur.