### PR TITLE
Revert "feat(ifl-891): fix create account to have correct chain head"

### DIFF
--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -6,8 +6,6 @@ import {
   Bech32m,
   JSONUtils,
   isValidPublicAddress,
-  IronfishSdk,
-  ImportResponse,
 } from '@ironfish/sdk'
 import { v4 as uuid } from 'uuid'
 import {
@@ -37,16 +35,10 @@ class AccountManager
   implements IIronfishAccountManager
 {
   private assetManager: AssetManager
-  private sdk: IronfishSdk
 
-  constructor(
-    node: IronfishNode,
-    assetManager: AssetManager,
-    sdk: IronfishSdk
-  ) {
+  constructor(node: IronfishNode, assetManager: AssetManager) {
     super(node)
     this.assetManager = assetManager
-    this.sdk = sdk
   }
 
   initEventListeners(): void {
@@ -129,6 +121,13 @@ class AccountManager
       default: defaultBalance,
       assets: assetBalances,
     }
+  }
+
+  async create(name: string): Promise<WalletAccount> {
+    return this.node.wallet.createAccount(name).then(account => {
+      this.onAccountCountChange()
+      return account.serialize()
+    })
   }
 
   async delete(name: string): Promise<void> {
@@ -290,21 +289,10 @@ class AccountManager
     }
   }
 
-  async submitAccount(createParams: AccountValue): Promise<ImportResponse> {
-    const client = await this.sdk.connectRpc()
-    const result = await client.wallet.importAccount({
-      account: {
-        ...createParams,
-        createdAt: createParams.createdAt
-          ? {
-              hash: createParams.createdAt.hash.toString('hex'),
-              sequence: createParams.createdAt.sequence,
-            }
-          : null,
-      },
-      rescan: !!createParams.createdAt,
-    })
-    return result.content
+  async submitAccount(createParams: AccountValue): Promise<WalletAccount> {
+    const newAccount = await this.node.wallet.importAccount(createParams)
+
+    return newAccount.serialize()
   }
 }
 

--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -202,7 +202,7 @@ export class IronFishManager implements IIronfishManager {
     await this.node.internal.save()
 
     this.assets = new AssetManager(this.node)
-    this.accounts = new AccountManager(this.node, this.assets, this.sdk)
+    this.accounts = new AccountManager(this.node, this.assets)
     this.transactions = new TransactionManager(this.node, this.assets)
     this.nodeSettings = new NodeSettingsManager(this.node)
     this.snapshot = new SnapshotManager(this.node)

--- a/src/data/DemoAccountsManager.ts
+++ b/src/data/DemoAccountsManager.ts
@@ -1,4 +1,4 @@
-import { AccountValue, CreateAccountResponse } from '@ironfish/sdk'
+import { AccountValue } from '@ironfish/sdk'
 import { nanoid } from 'nanoid'
 import randomWords from 'random-words'
 import AccountBalance from 'Types/AccountBalance'
@@ -225,7 +225,7 @@ class DemoAccountsManager implements IIronfishAccountManager {
     })
   }
 
-  create(name: string): Promise<CreateAccountResponse> {
+  create(name: string): Promise<AccountValue> {
     return new Promise(resolve => {
       setTimeout(() => {
         if (DEMO_ACCOUNTS.find(account => name === account.name)) {
@@ -260,7 +260,7 @@ class DemoAccountsManager implements IIronfishAccountManager {
           },
         ]
         this.onAccountCountChange()
-        resolve({ ...account, isDefaultAccount: false })
+        resolve(account)
       }, 500)
     })
   }
@@ -442,9 +442,7 @@ class DemoAccountsManager implements IIronfishAccountManager {
     }
   }
 
-  async submitAccount(
-    createParams: AccountValue
-  ): Promise<CreateAccountResponse> {
+  async submitAccount(createParams: AccountValue): Promise<Account> {
     return this.create(createParams.name)
   }
 }

--- a/types/IronfishManager/IIronfishAccountManager.ts
+++ b/types/IronfishManager/IIronfishAccountManager.ts
@@ -1,8 +1,4 @@
-import {
-  AccountValue,
-  CreateAccountResponse,
-  ImportResponse,
-} from '@ironfish/sdk'
+import { AccountValue } from '@ironfish/sdk'
 import AccountCreateParams from 'Types/AccountCreateParams'
 import Account from '../Account'
 import AccountBalance from '../AccountBalance'
@@ -32,6 +28,7 @@ export interface IIronfishAccountManager {
     default: AccountBalance
     assets: AccountBalance[]
   }>
+  create: (name: string) => Promise<Account>
   delete: (name: string) => Promise<void>
   export: (id: string, encoded?: boolean, viewOnly?: boolean) => Promise<string>
   get: (id: string) => Promise<Account>
@@ -42,5 +39,5 @@ export interface IIronfishAccountManager {
   isValidPublicAddress: (address: string) => Promise<boolean>
   list: (search?: string, sort?: SortType) => Promise<CutAccount[]>
   prepareAccount: () => Promise<AccountCreateParams>
-  submitAccount: (createParams: AccountValue) => Promise<ImportResponse>
+  submitAccount: (createParams: AccountValue) => Promise<Account>
 }


### PR DESCRIPTION
Using the RPC for account creation fails at the onboarding screen because the node is in an uninitialized state. I will revert this and add code to manually start the rescan.