### PR TITLE
fix: ironfish datadir changeable by env var

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -163,6 +163,7 @@ export class IronFishManager implements IIronfishManager {
     this.sdk = await IronfishSdk.init({
       pkg: getPackageFrom(pkg),
       logger: createAppLogger(),
+      dataDir: process.env.IRONFISH_DATA_DIR || undefined,
     })
 
     if (!this.sdk.internal.get('telemetryNodeId')) {


### PR DESCRIPTION
`IRONFISH_DATA_DIR="~/.nodeapp" yarn start:dev`
or
```
export IRONFISH_DATA_DIR="~/.nodeapp" 
yarn start:dev 
```