### PR TITLE
fix(ifl-976): restart app after snapshot

### DIFF
--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -306,6 +306,7 @@ class AccountManager
         }
       : createParams
     const newAccount = await this.node.wallet.importAccount(create)
+    this.node.wallet.scanTransactions()
 
     return newAccount.serialize()
   }

--- a/electron/ironfish/SnapshotManager.ts
+++ b/electron/ironfish/SnapshotManager.ts
@@ -13,7 +13,7 @@ import {
   SnapshotManifest,
 } from 'Types/IronfishManager/IIronfishSnapshotManager'
 import AbstractManager from './AbstractManager'
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, app } from 'electron'
 import EventType from 'Types/EventType'
 
 const MANIFEST_URL = 'https://snapshots.ironfish.network/manifest.json'
@@ -437,6 +437,8 @@ class SnapshotManager
       statistic: null,
       hasError: false,
     })
+    app.relaunch()
+    app.exit()
   }
 }
 

--- a/src/providers/SnapshotProvider.tsx
+++ b/src/providers/SnapshotProvider.tsx
@@ -74,7 +74,6 @@ const SnapshotProvider: FC<{ children: ReactNode }> = ({ children }) => {
     }
 
     if (status.status === SnapshotProgressStatus.COMPLETED) {
-      window.IronfishManager.initialize()
       window.IronfishManager.snapshot.reset()
     }
   }, [status?.status])


### PR DESCRIPTION
Restart app after snapshot loading is complete.

NOTE: if running with `yarn start:dev` this will start a blank app because it kills the yarn process.