### PR TITLE
fix: remove rpc call to account status

### DIFF
--- a/src/components/Navbar/StatusBar/NodeSyncStatus.tsx
+++ b/src/components/Navbar/StatusBar/NodeSyncStatus.tsx
@@ -71,13 +71,16 @@ const renderTime = (time: number) => {
 }
 
 const NodeSyncStatus: FC<DataSyncContextProps> = ({ data, synced }) => {
-  const leastSyncedAccount = data?.accounts?.reduce((prev, current) =>
-    !Number.isNaN(+current.sequence) &&
-    Number(current.sequence) < Number(data?.blockchain.head) &&
-    current.sequence < prev.sequence
-      ? current
-      : prev
-  )
+  const leastSyncedAccount =
+    data?.accounts?.length > 0
+      ? data.accounts.reduce((prev, current) =>
+          !Number.isNaN(+current.sequence) &&
+          Number(current.sequence) < Number(data?.blockchain.head) &&
+          current.sequence < prev.sequence
+            ? current
+            : prev
+        )
+      : undefined
   return (
     <>
       <chakra.h5 color="inherit">


### PR DESCRIPTION
My suspicion is that when the snapshot finishes download/dearchival, the code is trying restart the node or initialize the node, but that restart is interrupted by the fact that there is an RPC connection open.

This calls node directly instead to get the accounts.