### PR TITLE
feat(ifl-996): snapshot optional modal

### DIFF
--- a/electron/contextBridge/SnapshotManagerContext.ts
+++ b/electron/contextBridge/SnapshotManagerContext.ts
@@ -27,6 +27,12 @@ class SnapshotManagerContext implements IIronfishSnapshotManager {
       IronfishSnaphotManagerAction.APPLY
     )
   }
+  decline = () => {
+    return ipcRenderer.invoke(
+      'ironfish-manager-snapshot',
+      IronfishSnaphotManagerAction.DECLINE
+    )
+  }
   retry = () => {
     return ipcRenderer.invoke(
       'ironfish-manager-snapshot',

--- a/electron/ironfish/SnapshotManager.ts
+++ b/electron/ironfish/SnapshotManager.ts
@@ -148,6 +148,12 @@ class SnapshotManager
       })
   }
 
+  async decline() {
+    this.onStatusChange({
+      status: SnapshotProgressStatus.DECLINED,
+    })
+  }
+
   async retry(): Promise<void> {
     if (this.progress.status === SnapshotProgressStatus.NOT_STARTED) {
       return Promise.reject('Nothing to retry.')

--- a/src/components/Navbar/StatusBar/SnapshotRequirement.tsx
+++ b/src/components/Navbar/StatusBar/SnapshotRequirement.tsx
@@ -1,54 +1,31 @@
 import { FC, useState } from 'react'
-import { WarningIcon } from '@chakra-ui/icons'
 import sizeFormat from 'byte-size'
-import { Button, chakra } from '@ironfish/ui-kit'
+import { chakra } from '@ironfish/ui-kit'
 import useSnapshotManifest from 'Hooks/snapshot/useSnapshotManifest'
 import SnapshotDownloadModal from 'Components/Snapshot/SnapshotDownloadModal'
 import { formatRemainingTime } from 'Utils/remainingTimeFormat'
 import NodeStatusResponse from 'Types/NodeStatusResponse'
+import { useDataSync } from 'Providers/DataSyncProvider'
 
 const SnapshotRequirement: FC<{
   data: NodeStatusResponse | undefined
   isMinified: boolean
 }> = ({ data, isMinified }) => {
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(true)
   const [manifest] = useSnapshotManifest()
+  const { requiredSnapshot } = useDataSync()
 
   return (
     <>
-      <WarningIcon
-        display={isMinified ? 'inherit' : 'none'}
-        color="inherit"
-        w="1.25rem"
-        h="0.9375rem"
-        onClick={() => setOpen(true)}
-      />
       <chakra.h5
         color="inherit"
         m="0.5rem"
         display={isMinified ? 'none' : 'inherit'}
       >
-        You’re required to download our blockchain snapshot
-        <chakra.span display={isMinified ? 'block' : 'none'}>
-          Click on icon to download
-        </chakra.span>
+        Choosing how to sync the chain
       </chakra.h5>
-      <Button
-        variant="outline"
-        color="inherit"
-        borderColor="inherit"
-        borderRadius="4rem"
-        mb="1rem"
-        _hover={{
-          bg: 'var(--statusbar-hover-color)',
-        }}
-        display={{ base: 'none', sm: 'inline-flex' }}
-        onClick={() => setOpen(true)}
-      >
-        <chakra.h5 color="inherit">Download Snapshot</chakra.h5>
-      </Button>
       <SnapshotDownloadModal
-        isOpen={open}
+        isOpen={open && requiredSnapshot}
         onClose={() => setOpen(false)}
         onConfirm={() => {
           setOpen(false)

--- a/src/components/Snapshot/SnapshotDownloadModal.tsx
+++ b/src/components/Snapshot/SnapshotDownloadModal.tsx
@@ -2,10 +2,8 @@ import {
   Button,
   chakra,
   LightMode,
-  Link,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -58,6 +56,11 @@ const SnapshotDownloadModal: FC<
     setLoading(false)
   }, [manifest, byDefault])
 
+  const handleSyncing = useCallback(async () => {
+    window.IronfishManager.snapshot.decline()
+    onConfirm()
+  }, [manifest, byDefault])
+
   useEffect(() => {
     manifest &&
       checkPath(manifest).then(result => {
@@ -68,38 +71,43 @@ const SnapshotDownloadModal: FC<
 
   return (
     <LightMode>
-      <Modal {...props}>
+      <Modal {...props} closeOnOverlayClick={false}>
         <ModalOverlay background="rgba(0,0,0,0.75)" />
         <ModalContent p="4rem" minW="40rem" color={NAMED_COLORS.DEEP_BLUE}>
           <ModalHeader>
-            <chakra.h2>Download Snapshot</chakra.h2>
+            <chakra.h2>Syncing your chain</chakra.h2>
           </ModalHeader>
-          <ModalCloseButton
-            color={NAMED_COLORS.GREY}
-            borderRadius="50%"
-            borderColor={NAMED_COLORS.LIGHT_GREY}
-            border="0.0125rem solid"
-            mt="1.5rem"
-            mr="1.5rem"
-          />
           <ModalBody>
             <chakra.h4>
-              You need to download our chain snapshot as the normal download
-              time could take up to {estimateTime}. The snapshot will be 2 times
-              faster and only {size}.{' '}
-              <Link display="none">If you need help, please click here.</Link>
+              Choose how to sync your app with the blockchain: <br />
+              <br /> Download Snapshot: Fast and centralized. Get a complete
+              copy quickly from a central source. This method ensures efficiency
+              and consistent data. <br /> <br />
+              Sync from Peers: Slower but decentralized. Retrieve the blockchain
+              from other users, contributing to network decentralization. While
+              it may take longer, it strengthens the network's resilience.{' '}
             </chakra.h4>
             {error && <chakra.h4 color={NAMED_COLORS.RED}>{error}</chakra.h4>}
           </ModalBody>
           <ModalFooter justifyContent="flex-start">
             <Button
+              marginRight="16px"
               variant="primary"
               size="medium"
               disabled={loading}
               onClick={handleDownload}
               leftIcon={loading ? <Spinner /> : null}
             >
-              Download
+              Download Snapshot
+            </Button>
+            <Button
+              variant="primary"
+              size="medium"
+              disabled={loading}
+              onClick={handleSyncing}
+              leftIcon={loading ? <Spinner /> : null}
+            >
+              Sync from Peers
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/src/data/DemoSnapshotManager.ts
+++ b/src/data/DemoSnapshotManager.ts
@@ -46,6 +46,10 @@ class DemoSnapshotManager implements IIronfishSnapshotManager {
     return Promise.resolve()
   }
 
+  decline() {
+    return Promise.resolve()
+  }
+
   retry() {
     this.onStatusChange({
       hasError: false,

--- a/src/providers/DataSyncProvider.tsx
+++ b/src/providers/DataSyncProvider.tsx
@@ -38,8 +38,7 @@ export interface DataSyncContextProps {
   }
 }
 
-const CHAIN_SYNC_PROGRESS_THRESHOLD = 0.7
-const SNAPSHOT_VALUABLE_PROGRESS = 0.3
+const SNAPSHOT_VALUABLE_PROGRESS = 20
 
 const DataSyncContext = createContext<DataSyncContextProps>({
   synced: false,
@@ -90,21 +89,13 @@ const DataSyncProvider: FC<{ children: ReactNode }> = ({ children }) => {
       .catch(setError)
 
   const isSnapshotRequired = useMemo(() => {
-    if (status?.blockSyncer.syncing.progress > CHAIN_SYNC_PROGRESS_THRESHOLD) {
+    if (!manifest?.block_sequence) {
       return false
     }
-    if (
-      !status?.blockchain?.totalSequences ||
-      status?.blockchain?.totalSequences === '0' ||
-      !manifest?.block_sequence
-    ) {
-      return false
-    }
-    const total = Number(status?.blockchain?.totalSequences)
-    const headToSnapshot =
-      manifest.block_sequence - Number(status?.blockchain?.head)
-    const snapshotToTotal = headToSnapshot / total
-    return snapshotToTotal > SNAPSHOT_VALUABLE_PROGRESS
+    return (
+      Number(status?.blockchain?.head) < SNAPSHOT_VALUABLE_PROGRESS &&
+      snapshotStatus.status !== SnapshotProgressStatus.DECLINED
+    )
   }, [
     JSON.stringify(manifest),
     status?.blockSyncer.syncing.progress,

--- a/src/providers/SnapshotProvider.tsx
+++ b/src/providers/SnapshotProvider.tsx
@@ -77,6 +77,9 @@ const SnapshotProvider: FC<{ children: ReactNode }> = ({ children }) => {
       window.IronfishManager.initialize()
       window.IronfishManager.snapshot.reset()
     }
+    if (status.status === SnapshotProgressStatus.DECLINED) {
+      window.IronfishManager.sync()
+    }
   }, [status?.status])
 
   return (

--- a/src/routes/SnapshotFlow.tsx
+++ b/src/routes/SnapshotFlow.tsx
@@ -14,6 +14,7 @@ enum STEPS {
   UPDATING_DB,
   CLEARING_TEMP,
   COMPLETED,
+  DECLINED,
 }
 
 const getActiveStep = (status: SnapshotProgressStatus): number => {
@@ -29,6 +30,8 @@ const getActiveStep = (status: SnapshotProgressStatus): number => {
       return STEPS.CLEARING_TEMP
     case SnapshotProgressStatus.COMPLETED:
       return STEPS.COMPLETED
+    case SnapshotProgressStatus.DECLINED:
+      return STEPS.DECLINED
     default:
       return STEPS.DOWNLOADING
   }
@@ -68,7 +71,8 @@ const StepProgress: FC<{
           !status ||
           !status.total ||
           status?.status === SnapshotProgressStatus.NOT_STARTED ||
-          status?.status === SnapshotProgressStatus.COMPLETED
+          status?.status === SnapshotProgressStatus.COMPLETED ||
+          status?.status === SnapshotProgressStatus.DECLINED
         }
       />
     </Box>
@@ -100,9 +104,10 @@ const steps = [
 ]
 
 const SnapshotFlow: FC = () => {
-  const [status, setStatus] = useState<Omit<SnapshotProgressType, 'statistic'> | null>(
-    null
-  )
+  const [status, setStatus] = useState<Omit<
+    SnapshotProgressType,
+    'statistic'
+  > | null>(null)
 
   useEffect(() => {
     window.IronfishManager.snapshot.status().then(setStatus)
@@ -110,7 +115,10 @@ const SnapshotFlow: FC = () => {
   }, [])
 
   useEffect(() => {
-    if (status?.status === SnapshotProgressStatus.COMPLETED) {
+    if (
+      status?.status === SnapshotProgressStatus.COMPLETED ||
+      status?.status === SnapshotProgressStatus.DECLINED
+    ) {
       window.IronfishManager.start()
     }
   }, [status?.status])

--- a/types/IronfishManager/IIronfishSnapshotManager.ts
+++ b/types/IronfishManager/IIronfishSnapshotManager.ts
@@ -8,6 +8,7 @@ export enum IronfishSnaphotManagerAction {
   RETRY = 'retry',
   STATUS = 'status',
   RESET = 'reset',
+  DECLINE = 'decline',
 }
 
 export enum SnapshotProgressStatus {
@@ -18,6 +19,7 @@ export enum SnapshotProgressStatus {
   UNARHIVING,
   CLEARING_TEMP_DATA,
   COMPLETED,
+  DECLINED,
 }
 
 export interface SnapshotProgressType {
@@ -50,4 +52,5 @@ export interface IIronfishSnapshotManager {
   manifest: () => Promise<SnapshotManifest>
   reset: () => Promise<void>
   status: () => Promise<Omit<SnapshotProgressType, 'statistic'>>
+  decline: () => Promise<void>
 }


### PR DESCRIPTION
This PR does a few things:

1. Allows user to decline snapshot, this was an easier change because of how integrated the snapshot system is into the user flow (instead of making the snapshot an optional flow).
2. On decline, starts the node/peer network and begins syncing
3. Modal opens immediately after snapshot manifest is retrieved, rather than chain being initialized
4. Snapshot modal is not dismissible

Cancel download/Sync flow:

https://github.com/iron-fish/node-app/assets/26990067/8857bcd1-a69a-4c01-b117-742ffcd58814


Download complete flow:

https://github.com/iron-fish/node-app/assets/26990067/59462bd2-4750-4b11-bd83-eae0c5e9aa59

