### PR TITLE
[IFL-912] Remove info icon on mnemonic view

### DIFF
--- a/src/routes/Accounts/AccountTabs/Keys.tsx
+++ b/src/routes/Accounts/AccountTabs/Keys.tsx
@@ -102,6 +102,7 @@ const AccountKeys: FC<AccountKeysProps> = ({ account, exportAccount }) => {
           isReadOnly={true}
           mb="2rem"
           wordsAmount={24}
+          showInfoIcon={false}
         />
         <Flex alignItems={'center'} gap="2rem">
           <SelectField

--- a/src/routes/Onboarding/CreateAccount/CreateStep.tsx
+++ b/src/routes/Onboarding/CreateAccount/CreateStep.tsx
@@ -69,6 +69,7 @@ const CreateStep: FC<StepProps> = ({
         visible={true}
         mb="1rem"
         wordsAmount={24}
+        showInfoIcon={false}
       />
       <Box>
         <Checkbox

--- a/src/routes/Onboarding/CreateAccount/ValidateStep.tsx
+++ b/src/routes/Onboarding/CreateAccount/ValidateStep.tsx
@@ -88,6 +88,7 @@ const ValidateStep: FC<StepProps> = ({
           }
         }}
         wordsAmount={phrase.length}
+        showInfoIcon={false}
       />
       {error?.header && error?.message && (
         <Box mt="0.75rem">

--- a/src/routes/Onboarding/ImportAccount.tsx
+++ b/src/routes/Onboarding/ImportAccount.tsx
@@ -179,6 +179,7 @@ const MnemonicPhraseTab: FC<DesktopModeProps> = ({ desktopMode, onImport }) => {
         visible={true}
         isReadOnly={false}
         onChange={newWords => setPhrase(newWords)}
+        showInfoIcon={false}
       />
       <Box>
         <Button


### PR DESCRIPTION
Removes the info tooltip on the mnemonic view. IMO, any content that we may want to add behind a tooltip should just go below heading and always be visible.

Note that currently, the icon is there but there is no actual tooltip content.

<img width="666" alt="Screenshot 2023-05-25 at 3 20 35 PM" src="https://github.com/iron-fish/node-app/assets/3639170/2774b6f1-0c18-44d6-a2cd-06ebe37f26be">
