### PR TITLE
fix: bypass telemetry after initial selection

### DIFF
--- a/electron/contextBridge/IronfishManagerContext.ts
+++ b/electron/contextBridge/IronfishManagerContext.ts
@@ -1,4 +1,4 @@
-import { ConfigOptions } from '@ironfish/sdk'
+import { ConfigOptions, InternalOptions } from '@ironfish/sdk'
 import { ipcRenderer } from 'electron'
 import IIronfishManager, {
   IronfishManagerAction,
@@ -88,6 +88,15 @@ class IronfishManagerContext implements IIronfishManager {
       'ironfish-manager',
       IronfishManagerAction.SAVE_NODE_CONFIG,
       values
+    )
+  }
+  getInternalConfig = <T extends keyof InternalOptions>(
+    option: T
+  ): Promise<InternalOptions[T]> => {
+    return ipcRenderer.invoke(
+      'ironfish-manager',
+      IronfishManagerAction.GET_INTERNAL_CONFIG,
+      option
     )
   }
 }

--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -12,6 +12,7 @@ import {
   DatabaseVersionError,
   Peer as SDKPeer,
   GetWorkersStatusResponse,
+  InternalOptions,
 } from '@ironfish/sdk'
 import geoip from 'geoip-lite'
 import log from 'electron-log'
@@ -252,6 +253,12 @@ export class IronFishManager implements IIronfishManager {
 
   async hasAnyAccount(): Promise<boolean> {
     return Promise.resolve(this.node.wallet.listAccounts().length > 0)
+  }
+
+  async getInternalConfig<T extends keyof InternalOptions>(
+    option: T
+  ): Promise<InternalOptions[T]> {
+    return this.sdk.internal.get(option)
   }
 
   async initialize(): Promise<void> {

--- a/src/data/DemoDataManager.ts
+++ b/src/data/DemoDataManager.ts
@@ -1,4 +1,4 @@
-import { ConfigOptions } from '@ironfish/sdk'
+import { ConfigOptions, InternalOptions } from '@ironfish/sdk'
 import IronFishInitStatus from 'Types/IronfishInitStatus'
 import { IIronfishManager } from 'Types/IronfishManager/IIronfishManager'
 import Peer from 'Types/Peer'
@@ -65,6 +65,12 @@ class DemoDataManager implements IIronfishManager {
 
   async getNodeConfig(): Promise<Partial<ConfigOptions>> {
     return this.nodeSettings.getConfig()
+  }
+
+  async getInternalConfig<T extends keyof InternalOptions>(
+    option: T
+  ): Promise<InternalOptions[T]> {
+    return true as any
   }
 
   async hasAnyAccount(): Promise<boolean> {

--- a/src/routes/Initializing.tsx
+++ b/src/routes/Initializing.tsx
@@ -10,6 +10,8 @@ import NodeErrorMessagesModal from 'Components/ErrorMessagesModal'
 const Initializing: FC = () => {
   const [initStatus, setInitStatus] = useState<IronFishInitStatus | null>(null)
   const [hasAnyAccount, setHasAnyAccount] = useState<boolean | null>(null)
+  const [needsTelemetry, setNeedsTelemetry] = useState<boolean>(false)
+
   const [errors, setErrors] = useState<Error[]>([])
   const location = useLocation()
   const navigate = useNavigate()
@@ -20,6 +22,13 @@ const Initializing: FC = () => {
   const loadAccountCount = () => {
     window.IronfishManager.hasAnyAccount().then(setHasAnyAccount)
   }
+
+  const loadNeedsTelemetry = () => {
+    window.IronfishManager.getInternalConfig('isFirstRun').then(
+      setNeedsTelemetry
+    )
+  }
+
   const subscribeOnEvents = () => {
     window.subscribeOn(EventType.INIT_STATUS_CHANGE, setInitStatus)
     window.subscribeOn(EventType.ACCOUNTS_CHANGE, count =>
@@ -61,6 +70,7 @@ const Initializing: FC = () => {
       hasAnyAccount === null
     ) {
       loadAccountCount()
+      loadNeedsTelemetry()
       return
     }
 
@@ -93,7 +103,11 @@ const Initializing: FC = () => {
       location.pathname === ROUTES.CREATE ||
       location.pathname === ROUTES.BASE)
   ) {
-    navigate(ROUTES.TELEMETRY)
+    if (needsTelemetry) {
+      navigate(ROUTES.TELEMETRY)
+    } else {
+      navigate(ROUTES.ACCOUNTS)
+    }
   }
 
   // const currentStep = getActiveStep(initStatus)

--- a/types/IronfishManager/IIronfishManager.ts
+++ b/types/IronfishManager/IIronfishManager.ts
@@ -1,4 +1,4 @@
-import { ConfigOptions } from '@ironfish/sdk'
+import { ConfigOptions, InternalOptions } from '@ironfish/sdk'
 import IronFishInitStatus from '../IronfishInitStatus'
 import NodeStatusResponse from 'Types/NodeStatusResponse'
 
@@ -20,6 +20,7 @@ export enum IronfishManagerAction {
   NODE_STATUS = 'nodeStatus',
   PEERS = 'peers',
   SAVE_NODE_CONFIG = 'saveNodeConfig',
+  GET_INTERNAL_CONFIG = 'getInternalConfig',
   START = 'start',
   STATUS = 'status',
   STOP = 'stop',
@@ -49,6 +50,9 @@ export interface IIronfishManager {
   stop: (changeStatus?: boolean) => Promise<void>
   stopSyncing: () => Promise<void>
   sync: () => Promise<void>
+  getInternalConfig<T extends keyof InternalOptions>(
+    option: T
+  ): Promise<InternalOptions[T]>
 }
 
 export default IIronfishManager


### PR DESCRIPTION
Uses `isFirstRun` from `sdk.internal.config` to determine if we should prompt for telemetry.

Previously telemetry was always prompted for during startup.

https://github.com/iron-fish/node-app/assets/26990067/99d2f41b-497d-41d9-b654-5445140144da


