### PR TITLE
feat(node-app): Catch errors and abstract into a resolved error response

### DIFF
--- a/electron/common/initHandlers.ts
+++ b/electron/common/initHandlers.ts
@@ -24,18 +24,41 @@ async function shutdownNode() {
   return await ironfishManager.stop()
 }
 
+function handleError(error: unknown): {
+  error: true
+  message: string
+  name?: string
+  stack?: string
+} {
+  if (error.isAxiosError) {
+    log.error(error?.code, '|', error?.config?.url, '|', error?.message)
+  } else {
+    log.error(error)
+  }
+
+  if (error instanceof Error) {
+    return {
+      error: true,
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    }
+  }
+
+  return {
+    error: true,
+    message: String(error),
+  }
+}
+
 ipcMain.handle(
   'ironfish-manager',
   async (e, action: IronfishManagerAction, ...args): Promise<any> => {
-    let result
     try {
-      result = await ironfishManager[action](...args)
+      return await ironfishManager[action](...args)
     } catch (error) {
-      // eslint-disable-next-line no-console
-      log.error(error)
+      return handleError(error)
     }
-
-    return result
   }
 )
 
@@ -44,28 +67,21 @@ ipcMain.handle(
   async (e, action: IronfishAssetManagerActions, ...args): Promise<any> => {
     let result
     try {
-      result = await ironfishManager.assets[action](...args)
+      return await ironfishManager.assets[action](...args)
     } catch (error) {
-      // eslint-disable-next-line no-console
-      log.error(error)
+      return handleError(error)
     }
-
-    return result
   }
 )
 
 ipcMain.handle(
   'ironfish-manager-accounts',
   async (e, action: IronfishAccountManagerAction, ...args): Promise<any> => {
-    let result
     try {
-      result = await ironfishManager.accounts[action](...args)
+      return await ironfishManager.accounts[action](...args)
     } catch (error) {
-      // eslint-disable-next-line no-console
-      log.error(error)
+      return handleError(error)
     }
-
-    return result
   }
 )
 
@@ -76,28 +92,21 @@ ipcMain.handle(
     action: IronfishTransactionManagerAction,
     ...args
   ): Promise<any> => {
-    let result
     try {
-      result = await ironfishManager.transactions[action](...args)
+      return await ironfishManager.transactions[action](...args)
     } catch (error) {
-      // eslint-disable-next-line no-console
-      log.error(error)
-      throw new Error(error.message)
+      return handleError(error)
     }
-
-    return result
   }
 )
 
 ipcMain.handle(
   'ironfish-manager-snapshot',
   async (e, action: IronfishSnaphotManagerAction, ...args): Promise<any> => {
-    let result
     try {
-      result = await ironfishManager.snapshot[action](...args)
+      return await ironfishManager.snapshot[action](...args)
     } catch (error) {
-      // eslint-disable-next-line no-console
-      log.error(error)
+      return handleError(error)
     }
 
     return result
@@ -107,18 +116,11 @@ ipcMain.handle(
 ipcMain.handle(
   'update-manager',
   async (e, action: UpdateManagerAction, ...args) => {
-    let result
     try {
-      result = await UpdateManager[action](...args)
+      return await UpdateManager[action](...args)
     } catch (error) {
-      if (error.isAxiosError) {
-        log.error(error?.code, '|', error?.config?.url, '|', error?.message)
-      } else {
-        log.error(error)
-      }
+      return handleError(error)
     }
-
-    return result
   }
 )
 
@@ -127,13 +129,10 @@ ipcMain.handle(
   async (e, action: ErrorManagerActions, ...args) => {
     let result
     try {
-      result = await errorManager[action](...args)
+      return await errorManager[action](...args)
     } catch (error) {
-      // eslint-disable-next-line no-console
-      log.error(error)
+      return handleError(error)
     }
-
-    return result
   }
 )
 

--- a/electron/contextBridge/AccountManagerContext.ts
+++ b/electron/contextBridge/AccountManagerContext.ts
@@ -1,21 +1,21 @@
 import { AccountValue } from '@ironfish/sdk'
-import { ipcRenderer } from 'electron'
 import {
   IIronfishAccountManager,
   IronfishAccountManagerAction,
 } from 'Types/IronfishManager/IIronfishAccountManager'
 import SortType from 'Types/SortType'
+import { invoke } from './util'
 
 class AccountManagerContext implements IIronfishAccountManager {
   importByEncodedKey = (data: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.IMPORT_BY_ENCODED_KEY,
       data
     )
   }
   importByMnemonic = (name: string, mnemonic: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.IMPORT_BY_MNEMONIC,
       name,
@@ -23,27 +23,27 @@ class AccountManagerContext implements IIronfishAccountManager {
     )
   }
   create = (name: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.CREATE,
       name
     )
   }
   prepareAccount = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.PREPARE_ACCOUNT
     )
   }
   submitAccount = (createParams: AccountValue) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.SUBMIT_ACCOUNT,
       createParams
     )
   }
   list = (search?: string, sort?: SortType) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.LIST,
       search,
@@ -51,35 +51,35 @@ class AccountManagerContext implements IIronfishAccountManager {
     )
   }
   get = (id: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.GET,
       id
     )
   }
   delete = (name: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.DELETE,
       name
     )
   }
   import = (account: Omit<AccountValue, 'rescan'>) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.IMPORT,
       account
     )
   }
   isValidPublicAddress = (address: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.IS_VALID_PUBLIC_ADDRESS,
       address
     )
   }
   export = (id: string, encode?: boolean, viewOnly?: boolean) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.EXPORT,
       id,
@@ -88,7 +88,7 @@ class AccountManagerContext implements IIronfishAccountManager {
     )
   }
   balance = (id: string, assetId?: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.BALANCE,
       id,
@@ -96,14 +96,14 @@ class AccountManagerContext implements IIronfishAccountManager {
     )
   }
   balances = (id: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.BALANCES,
       id
     )
   }
   getMnemonicPhrase = (id: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-accounts',
       IronfishAccountManagerAction.GET_MNEMONIC_PHRASE,
       id

--- a/electron/contextBridge/AssetManagerContext.ts
+++ b/electron/contextBridge/AssetManagerContext.ts
@@ -1,11 +1,11 @@
-import { ipcRenderer } from 'electron'
 import IIronfishAssetManager, {
   IronfishAssetManagerActions,
 } from 'Types/IronfishManager/IIronfishAssetManager'
+import { invoke } from './util'
 
 class AssetManagerContext implements IIronfishAssetManager {
   list = (search?: string, offset?: number, max?: number) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-assets',
       IronfishAssetManagerActions.LIST,
       search,
@@ -14,14 +14,14 @@ class AssetManagerContext implements IIronfishAssetManager {
     )
   }
   get = (id: string | Buffer) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-assets',
       IronfishAssetManagerActions.GET,
       id
     )
   }
   default = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-assets',
       IronfishAssetManagerActions.DEFAULT
     )

--- a/electron/contextBridge/ErrorManagerContext.ts
+++ b/electron/contextBridge/ErrorManagerContext.ts
@@ -1,15 +1,14 @@
-import { ipcRenderer } from 'electron'
 import IErrorManager, { ErrorManagerActions } from 'Types/ErrorManagerTypes'
+import { invoke } from './util'
 
 class ErrorManagerContext implements IErrorManager {
   addError = (error: Error) =>
-    ipcRenderer.invoke('error-manager', ErrorManagerActions.ADD_ERROR, error)
+    invoke('error-manager', ErrorManagerActions.ADD_ERROR, error)
 
-  getErrors = () =>
-    ipcRenderer.invoke('error-manager', ErrorManagerActions.GET_ERRORS)
+  getErrors = () => invoke('error-manager', ErrorManagerActions.GET_ERRORS)
 
   processError = (closeOnLastProcessed: boolean) =>
-    ipcRenderer.invoke(
+    invoke(
       'error-manager',
       ErrorManagerActions.PROCESS_ERROR,
       closeOnLastProcessed

--- a/electron/contextBridge/IronfishManagerContext.ts
+++ b/electron/contextBridge/IronfishManagerContext.ts
@@ -1,5 +1,4 @@
 import { ConfigOptions, InternalOptions } from '@ironfish/sdk'
-import { ipcRenderer } from 'electron'
 import IIronfishManager, {
   IronfishManagerAction,
 } from 'Types/IronfishManager/IIronfishManager'
@@ -8,6 +7,7 @@ import AssetManagerContext from './AssetManagerContext'
 import NodeSettingsManagerContext from './NodeSettingsManagerContext'
 import TransactionManagerContext from './TransactionManagerContext'
 import SnapshotManagerContext from './SnapshotManagerContext'
+import { invoke } from './util'
 
 class IronfishManagerContext implements IIronfishManager {
   accounts = AccountManagerContext
@@ -17,74 +17,51 @@ class IronfishManagerContext implements IIronfishManager {
   nodeSettings = NodeSettingsManagerContext
 
   initialize = () =>
-    ipcRenderer.invoke('ironfish-manager', IronfishManagerAction.INITIALIZE)
+    invoke('ironfish-manager', IronfishManagerAction.INITIALIZE)
   isFirstRun = () =>
-    ipcRenderer.invoke('ironfish-manager', IronfishManagerAction.IS_FIRST_RUN)
+    invoke('ironfish-manager', IronfishManagerAction.IS_FIRST_RUN)
   hasAnyAccount = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      IronfishManagerAction.HAS_ANY_ACCOUNT
-    )
+    return invoke('ironfish-manager', IronfishManagerAction.HAS_ANY_ACCOUNT)
   }
   start = () => {
-    return ipcRenderer.invoke('ironfish-manager', IronfishManagerAction.START)
+    return invoke('ironfish-manager', IronfishManagerAction.START)
   }
   stop = (changeStatus?: boolean) => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      IronfishManagerAction.STOP,
-      changeStatus
-    )
+    return invoke('ironfish-manager', IronfishManagerAction.STOP, changeStatus)
   }
   status = () => {
-    return ipcRenderer.invoke('ironfish-manager', IronfishManagerAction.STATUS)
+    return invoke('ironfish-manager', IronfishManagerAction.STATUS)
   }
   sync = () => {
-    return ipcRenderer.invoke('ironfish-manager', IronfishManagerAction.SYNC)
+    return invoke('ironfish-manager', IronfishManagerAction.SYNC)
   }
   stopSyncing = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      IronfishManagerAction.STOP_SYNCING
-    )
+    return invoke('ironfish-manager', IronfishManagerAction.STOP_SYNCING)
   }
   chainProgress = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      IronfishManagerAction.CHAIN_PROGRESS
-    )
+    return invoke('ironfish-manager', IronfishManagerAction.CHAIN_PROGRESS)
   }
   downloadChainSnapshot = (path?: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager',
       IronfishManagerAction.DOWNLOAD_SNAPSHOT,
       path
     )
   }
   dump = (errors: Error[]) => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      IronfishManagerAction.DUMP,
-      errors
-    )
+    return invoke('ironfish-manager', IronfishManagerAction.DUMP, errors)
   }
   nodeStatus = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      IronfishManagerAction.NODE_STATUS
-    )
+    return invoke('ironfish-manager', IronfishManagerAction.NODE_STATUS)
   }
   peers = () => {
-    return ipcRenderer.invoke('ironfish-manager', IronfishManagerAction.PEERS)
+    return invoke('ironfish-manager', IronfishManagerAction.PEERS)
   }
   getNodeConfig = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      IronfishManagerAction.GET_NODE_CONFIG
-    )
+    return invoke('ironfish-manager', IronfishManagerAction.GET_NODE_CONFIG)
   }
   saveNodeConfig = (values: Partial<ConfigOptions>) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager',
       IronfishManagerAction.SAVE_NODE_CONFIG,
       values
@@ -93,7 +70,7 @@ class IronfishManagerContext implements IIronfishManager {
   getInternalConfig = <T extends keyof InternalOptions>(
     option: T
   ): Promise<InternalOptions[T]> => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager',
       IronfishManagerAction.GET_INTERNAL_CONFIG,
       option

--- a/electron/contextBridge/NodeSettingsManagerContext.ts
+++ b/electron/contextBridge/NodeSettingsManagerContext.ts
@@ -1,35 +1,26 @@
 import { ConfigOptions } from '@ironfish/sdk'
-import { ipcRenderer } from 'electron'
 import {
   INodeSettingsManager,
   NodeSettingsManagerAction,
 } from 'Types/IronfishManager/INodeSettingsManager'
+import { invoke } from './util'
 
 class NodeSettingsManagerContext implements INodeSettingsManager {
   getConfig = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      NodeSettingsManagerAction.GET_CONFIG
-    )
+    return invoke('ironfish-manager', NodeSettingsManagerAction.GET_CONFIG)
   }
   setValues = (values: Partial<ConfigOptions>) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager',
       NodeSettingsManagerAction.SET_VALUES,
       values
     )
   }
   save = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      NodeSettingsManagerAction.SAVE
-    )
+    return invoke('ironfish-manager', NodeSettingsManagerAction.SAVE)
   }
   clearConfig = () => {
-    return ipcRenderer.invoke(
-      'ironfish-manager',
-      NodeSettingsManagerAction.CLEAR_CONFIG
-    )
+    return invoke('ironfish-manager', NodeSettingsManagerAction.CLEAR_CONFIG)
   }
 }
 

--- a/electron/contextBridge/SnapshotManagerContext.ts
+++ b/electron/contextBridge/SnapshotManagerContext.ts
@@ -1,13 +1,13 @@
-import { ipcRenderer } from 'electron'
 import {
   IIronfishSnapshotManager,
   IronfishSnaphotManagerAction,
   SnapshotManifest,
 } from 'Types/IronfishManager/IIronfishSnapshotManager'
+import { invoke } from './util'
 
 class SnapshotManagerContext implements IIronfishSnapshotManager {
   checkPath = (manifest: SnapshotManifest, pathToSave?: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.CHECK_PATH,
       manifest,
@@ -15,44 +15,44 @@ class SnapshotManagerContext implements IIronfishSnapshotManager {
     )
   }
   start = (pathToSave?: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.START,
       pathToSave
     )
   }
   apply = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.APPLY
     )
   }
   decline = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.DECLINE
     )
   }
   retry = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.RETRY
     )
   }
   manifest = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.MANIFEST
     )
   }
   reset = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.RESET
     )
   }
   status = () => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-snapshot',
       IronfishSnaphotManagerAction.STATUS
     )

--- a/electron/contextBridge/StorageContext.ts
+++ b/electron/contextBridge/StorageContext.ts
@@ -1,7 +1,7 @@
 import IStorage from 'Types/IStorage'
 import SortType from 'Types/SortType'
 import Entity from 'Types/Entity'
-import { ipcRenderer } from 'electron'
+import { invoke } from './util'
 
 class StorageContext implements IStorage<Entity> {
   name: string
@@ -11,22 +11,22 @@ class StorageContext implements IStorage<Entity> {
   }
 
   list = (searchTerm: string, sort: SortType) => {
-    return ipcRenderer.invoke(this.name + '-list', searchTerm, sort)
+    return invoke(this.name + '-list', searchTerm, sort)
   }
   get = (identity: string) => {
-    return ipcRenderer.invoke(this.name + '-get', identity)
+    return invoke(this.name + '-get', identity)
   }
   add = (entity: Omit<Entity, '_id'>) => {
-    return ipcRenderer.invoke(this.name + '-add', entity)
+    return invoke(this.name + '-add', entity)
   }
   update = (identity: string, fieldsToUpdate: Partial<Omit<Entity, '_id'>>) => {
-    return ipcRenderer.invoke(this.name + '-update', identity, fieldsToUpdate)
+    return invoke(this.name + '-update', identity, fieldsToUpdate)
   }
   delete = (identity: string) => {
-    return ipcRenderer.invoke(this.name + '-delete', identity)
+    return invoke(this.name + '-delete', identity)
   }
   find = (entity: Partial<Omit<Entity, '_id'>>) => {
-    return ipcRenderer.invoke(this.name + '-find', entity)
+    return invoke(this.name + '-find', entity)
   }
 }
 

--- a/electron/contextBridge/TransactionManagerContext.ts
+++ b/electron/contextBridge/TransactionManagerContext.ts
@@ -1,14 +1,14 @@
-import { ipcRenderer } from 'electron'
 import {
   IIronfishTransactionManager,
   IronfishTransactionManagerAction,
 } from 'Types/IronfishManager/IIronfishTransactionManager'
 import SortType from 'Types/SortType'
 import { Payment } from 'Types/Transaction'
+import { invoke } from './util'
 
 class TransactionManagerContext implements IIronfishTransactionManager {
   estimateFeeWithPriority = (accountId: string, receive: Payment) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-transactions',
       IronfishTransactionManagerAction.ESTIMATE_FEE,
       accountId,
@@ -21,7 +21,7 @@ class TransactionManagerContext implements IIronfishTransactionManager {
     searchTerm?: string,
     sort?: SortType
   ) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-transactions',
       IronfishTransactionManagerAction.FIND_BY_ACCOUNT_ID,
       accountId,
@@ -31,7 +31,7 @@ class TransactionManagerContext implements IIronfishTransactionManager {
   }
 
   findByAddress = (address: string, searchTerm?: string, sort?: SortType) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-transactions',
       IronfishTransactionManagerAction.FIND_BY_ADDRESS,
       address,
@@ -41,7 +41,7 @@ class TransactionManagerContext implements IIronfishTransactionManager {
   }
 
   get = (hash: string, accountId: string) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-transactions',
       IronfishTransactionManagerAction.GET,
       hash,
@@ -50,7 +50,7 @@ class TransactionManagerContext implements IIronfishTransactionManager {
   }
 
   send = (accountId: string, payment: Payment, transactionFee?: bigint) => {
-    return ipcRenderer.invoke(
+    return invoke(
       'ironfish-manager-transactions',
       IronfishTransactionManagerAction.SEND,
       accountId,

--- a/electron/contextBridge/UpdateManagerContext.ts
+++ b/electron/contextBridge/UpdateManagerContext.ts
@@ -1,4 +1,3 @@
-import { ipcRenderer } from 'electron'
 import {
   IUpdateManager,
   ReleaseNote,
@@ -6,31 +5,23 @@ import {
   UpdateReleaseNotesResponse,
   UpdateStatus,
 } from 'Types/IUpdateManager'
+import { invoke } from './util'
 
 class UpdateManagerContext implements IUpdateManager {
   initialize: () => Promise<void> = () => {
-    return ipcRenderer.invoke('update-manager', UpdateManagerAction.INITIALIZE)
+    return invoke('update-manager', UpdateManagerAction.INITIALIZE)
   }
   checkUpdates: () => Promise<UpdateStatus> = () => {
-    return ipcRenderer.invoke(
-      'update-manager',
-      UpdateManagerAction.CHECK_UPDATES
-    )
+    return invoke('update-manager', UpdateManagerAction.CHECK_UPDATES)
   }
   ignoreUpdates: () => Promise<UpdateStatus> = () => {
-    return ipcRenderer.invoke(
-      'update-manager',
-      UpdateManagerAction.IGNORE_UPDATES
-    )
+    return invoke('update-manager', UpdateManagerAction.IGNORE_UPDATES)
   }
   resetError: () => Promise<UpdateStatus> = () => {
-    return ipcRenderer.invoke('update-manager', UpdateManagerAction.RESET_ERROR)
+    return invoke('update-manager', UpdateManagerAction.RESET_ERROR)
   }
   installUpdates: () => Promise<void> = () => {
-    return ipcRenderer.invoke(
-      'update-manager',
-      UpdateManagerAction.INSTALL_UPDATES
-    )
+    return invoke('update-manager', UpdateManagerAction.INSTALL_UPDATES)
   }
   notes: (
     after?: string,
@@ -39,25 +30,13 @@ class UpdateManagerContext implements IUpdateManager {
     after?: string,
     limit?: number
   ) => {
-    return ipcRenderer.invoke(
-      'update-manager',
-      UpdateManagerAction.NOTES,
-      after,
-      limit
-    )
+    return invoke('update-manager', UpdateManagerAction.NOTES, after, limit)
   }
   note: (version: string) => Promise<ReleaseNote> = (version: string) => {
-    return ipcRenderer.invoke(
-      'update-manager',
-      UpdateManagerAction.NOTE,
-      version
-    )
+    return invoke('update-manager', UpdateManagerAction.NOTE, version)
   }
   getNewVersions: () => Promise<string[]> = () => {
-    return ipcRenderer.invoke(
-      'update-manager',
-      UpdateManagerAction.GET_VERSIONS_BEFORE
-    )
+    return invoke('update-manager', UpdateManagerAction.GET_VERSIONS_BEFORE)
   }
 }
 

--- a/electron/contextBridge/util.ts
+++ b/electron/contextBridge/util.ts
@@ -1,0 +1,14 @@
+import { ipcRenderer } from 'electron'
+
+export async function invoke(channel: string, ...args: any[]): Promise<any> {
+  try {
+    const response = await ipcRenderer.invoke(channel, ...args)
+    if (response?.error) {
+      throw response
+    }
+
+    return response
+  } catch (error) {
+    return new Promise((_, reject) => reject(error))
+  }
+}


### PR DESCRIPTION
## Description

Error handling does not work at all between the main process and renderer process.

When using IPC between the main process and renderer process for Electron, promises cannot handle custom error objects and therefore exception traces are lost between the caller and callee. The serializer in the engine that runs JS breaks down with these custom error objects; nothing can catch these exceptions so the error is lost in translation.

To mitigate this issue, this code change includes a work around to always resolve error responses into a JSON object where an `error` field is set to true. If available, the `name`, `message`, and `stack` are set as well. If the receiving end gets an object with `error` being defined and truthy, the renderer process then creates a rejected error with appropriate fields set.

## Testing Plan

Testing importing a duplicate account and monitoring the consoles. Before, this would show a successful toast.

<img width="535" alt="Screen Shot 2023-05-31 at 3 26 37 PM" src="https://github.com/iron-fish/node-app/assets/5459049/0c323cb6-af14-4030-bfda-738254a406d1">
