### PR TITLE
feat(ifl-1047): reset node and confirm modal

### DIFF
--- a/electron/contextBridge/IronfishManagerContext.ts
+++ b/electron/contextBridge/IronfishManagerContext.ts
@@ -76,6 +76,12 @@ class IronfishManagerContext implements IIronfishManager {
       option
     )
   }
+  resetNode = () => {
+    return invoke('ironfish-manager', IronfishManagerAction.RESET_NODE)
+  }
+  restartApp = () => {
+    return invoke('ironfish-manager', IronfishManagerAction.RESTART_APP)
+  }
 }
 
 export default new IronfishManagerContext()

--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -162,9 +162,7 @@ export class IronFishManager implements IIronfishManager {
 
   // used to reset node if datadir exists but is incompatible with mainnet
   async resetNode(): Promise<void> {
-    log.log(
-      '----------- resetting chain due to network incompatibility ----------------'
-    )
+    log.log('Resetting node')
     await this.node.shutdown()
     await this.node.closeDB()
     const hostFilePath: string = this.sdk.config.files.join(
@@ -199,6 +197,12 @@ export class IronFishManager implements IIronfishManager {
       privateIdentity: this.getPrivateIdentity(),
       autoSeed: true,
     })
+    log.log('Node reset complete')
+  }
+
+  async restartApp(): Promise<void> {
+    app.relaunch()
+    app.exit()
   }
 
   private async initializeSdk(): Promise<void> {
@@ -238,6 +242,9 @@ export class IronFishManager implements IIronfishManager {
         this.node.config.get('networkId') !== 1) &&
       (app.isPackaged || process.env.ENABLE_RESET)
     ) {
+      log.log(
+        '----------- resetting chain due to network incompatibility ----------------'
+      )
       await this.resetNode()
     }
 

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,102 @@
+import {
+  Button,
+  chakra,
+  LightMode,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalProps,
+  NAMED_COLORS,
+  TextField,
+} from '@ironfish/ui-kit'
+import { FC, useState } from 'react'
+
+const ConfirmModal: FC<
+  Omit<ModalProps, 'children'> & {
+    title: string
+    description: string
+    validationText: string
+    onConfirm: () => void
+    buttonText?: string
+    buttonColor?: string
+  }
+> = ({
+  onConfirm,
+  title,
+  description,
+  validationText,
+  buttonText = 'Confirm',
+  buttonColor = '#F15929',
+  ...props
+}) => {
+  const [textMatch, setTextMatch] = useState(false)
+
+  const handleConfirm = () => {
+    if (textMatch) {
+      onConfirm()
+    }
+  }
+
+  return (
+    <LightMode>
+      <Modal {...props}>
+        <ModalOverlay background="rgba(0,0,0,0.75)" />
+        <ModalContent p="4rem" minW="40rem" color={NAMED_COLORS.DEEP_BLUE}>
+          <ModalCloseButton
+            border="0.0625rem solid"
+            borderRadius="50%"
+            color={NAMED_COLORS.GREY}
+            borderColor={NAMED_COLORS.LIGHT_GREY}
+            top="1.5rem"
+            right="1.5rem"
+            w="2.375rem"
+            h="2.375rem"
+            _focus={{
+              boxShadow: 'none',
+            }}
+          />
+          <ModalHeader>
+            <chakra.h2>{title}</chakra.h2>
+          </ModalHeader>
+          <ModalBody>
+            <chakra.h4 marginBottom="16px">{description}</chakra.h4>
+            <TextField
+              label={`Enter "${validationText}" to confirm`}
+              placeholder={validationText}
+              InputProps={{
+                onChange: e => setTextMatch(e.target.value === validationText),
+              }}
+            />
+          </ModalBody>
+          <ModalFooter justifyContent="flex-start">
+            <Button
+              variant="primary"
+              size="medium"
+              isDisabled={!textMatch}
+              onClick={handleConfirm}
+              backgroundColor={buttonColor}
+              mr="1.5rem"
+            >
+              {buttonText}
+            </Button>
+            <Link
+              alignSelf="center"
+              onClick={() => {
+                props.onClose()
+              }}
+            >
+              <h4>Cancel</h4>
+            </Link>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </LightMode>
+  )
+}
+
+export default ConfirmModal

--- a/src/components/ErrorMessagesModal.tsx
+++ b/src/components/ErrorMessagesModal.tsx
@@ -1,10 +1,8 @@
 import {
   Button,
-  CheckIcon,
   Flex,
   Spinner,
   chakra,
-  Input,
   Textarea,
   CopyValueToClipboard,
   NAMED_COLORS,

--- a/src/data/DemoDataManager.ts
+++ b/src/data/DemoDataManager.ts
@@ -15,6 +15,7 @@ import { IIronfishTransactionManager } from 'Types/IronfishManager/IIronfishTran
 import { IIronfishSnapshotManager } from 'Types/IronfishManager/IIronfishSnapshotManager'
 import { INodeSettingsManager } from 'Types/IronfishManager/INodeSettingsManager'
 import EventType from 'Types/EventType'
+import { app } from 'electron'
 
 class DemoDataManager implements IIronfishManager {
   private internalConfig = { isFirstRun: true }
@@ -151,6 +152,14 @@ class DemoDataManager implements IIronfishManager {
 
   async sync(): Promise<void> {
     return this.node.sync()
+  }
+
+  async resetNode(): Promise<void> {
+    return
+  }
+
+  async restartApp(): Promise<void> {
+    return
   }
 }
 

--- a/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
+++ b/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
@@ -12,13 +12,16 @@ import {
   FormControl,
   FormLabel,
   Switch,
+  Link,
 } from '@ironfish/ui-kit'
+import { RepeatIcon } from '@chakra-ui/icons'
 import useNodeSettings from 'Hooks/node/useNodeSettings'
 import { FC, useState, useEffect, memo, useMemo } from 'react'
 import pick from 'lodash/pick'
 import DetailsPanel from 'Components/DetailsPanel'
 import AccountSettingsImage from 'Svgx/AccountSettingsImage'
 import NodeWorkersSelect from './NodeWorkersSelect'
+import ConfirmModal from 'Components/ConfirmModal'
 
 const Information: FC = memo(() => {
   return (
@@ -48,6 +51,7 @@ const SETTINGS_KEYS = [
 
 const NodeSettings: FC = () => {
   const [nodeSettings, setNodeSettings] = useState<Partial<ConfigOptions>>({})
+  const [openConfirmReset, setOpenConfirmReset] = useState(false)
   const {
     data,
     loaded,
@@ -73,6 +77,12 @@ const NodeSettings: FC = () => {
     saveSettings(nodeSettings).then(() => toast({ title: 'Settings saved' }))
   }
 
+  const handleResetNode = () => {
+    window.IronfishManager.resetNode().then(() => {
+      window.IronfishManager.restartApp()
+    })
+  }
+
   const hasNoChanges = useMemo(
     () =>
       !(
@@ -87,61 +97,62 @@ const NodeSettings: FC = () => {
   )
 
   return (
-    <Flex>
-      <Flex display="column">
-        <Grid
-          w="37.25rem"
-          templateColumns="repeat(2, 1fr)"
-          gridAutoRows={'auto'}
-          gap="2rem"
-        >
-          <Skeleton variant="ironFish" isLoaded={!!data}>
-            <TextField
-              label="Node name"
-              value={nodeSettings?.nodeName}
-              InputProps={{
-                onChange: e => updateSettingValue('nodeName', e.target.value),
-              }}
-            />
-          </Skeleton>
-          <Skeleton variant="ironFish" isLoaded={!!data}>
-            <TextField
-              label="Block graffiti"
-              value={nodeSettings?.blockGraffiti}
-              InputProps={{
-                onChange: e =>
-                  updateSettingValue('blockGraffiti', e.target.value),
-              }}
-            />
-          </Skeleton>
-          <Skeleton variant="ironFish" isLoaded={!!data}>
-            <TextField
-              label="Min Peers"
-              value={nodeSettings?.minPeers?.toString()}
-              InputProps={{
-                type: 'number',
-                onChange: e => updateSettingValue('minPeers', e.target.value),
-              }}
-            />
-          </Skeleton>
-          <Skeleton variant="ironFish" isLoaded={!!data}>
-            <TextField
-              label="Max peers"
-              value={nodeSettings?.maxPeers?.toString()}
-              InputProps={{
-                type: 'number',
-                onChange: e => updateSettingValue('maxPeers', e.target.value),
-              }}
-            />
-          </Skeleton>
-          <Skeleton variant="ironFish" isLoaded={!!data}>
-            <NodeWorkersSelect
-              value={nodeSettings?.nodeWorkers?.toString()}
-              onSelectOption={selected =>
-                updateSettingValue('nodeWorkers', selected.value)
-              }
-            />
-            {/* <TextField
+    <>
+      <Flex>
+        <Flex display="column">
+          <Grid
+            w="37.25rem"
+            templateColumns="repeat(2, 1fr)"
+            gridAutoRows={'auto'}
+            gap="2rem"
+          >
+            <Skeleton variant="ironFish" isLoaded={!!data}>
+              <TextField
+                label="Node name"
+                value={nodeSettings?.nodeName}
+                InputProps={{
+                  onChange: e => updateSettingValue('nodeName', e.target.value),
+                }}
+              />
+            </Skeleton>
+            <Skeleton variant="ironFish" isLoaded={!!data}>
+              <TextField
+                label="Block graffiti"
+                value={nodeSettings?.blockGraffiti}
+                InputProps={{
+                  onChange: e =>
+                    updateSettingValue('blockGraffiti', e.target.value),
+                }}
+              />
+            </Skeleton>
+            <Skeleton variant="ironFish" isLoaded={!!data}>
+              <TextField
+                label="Min Peers"
+                value={nodeSettings?.minPeers?.toString()}
+                InputProps={{
+                  type: 'number',
+                  onChange: e => updateSettingValue('minPeers', e.target.value),
+                }}
+              />
+            </Skeleton>
+            <Skeleton variant="ironFish" isLoaded={!!data}>
+              <TextField
+                label="Max peers"
+                value={nodeSettings?.maxPeers?.toString()}
+                InputProps={{
+                  type: 'number',
+                  onChange: e => updateSettingValue('maxPeers', e.target.value),
+                }}
+              />
+            </Skeleton>
+            <Skeleton variant="ironFish" isLoaded={!!data}>
+              <NodeWorkersSelect
+                value={nodeSettings?.nodeWorkers?.toString()}
+                onSelectOption={selected =>
+                  updateSettingValue('nodeWorkers', selected.value)
+                }
+              />
+              {/* <TextField
               label="Node workers"
               value={nodeSettings?.nodeWorkers?.toString()}
               InputProps={{
@@ -150,58 +161,80 @@ const NodeSettings: FC = () => {
                   updateSettingValue('nodeWorkers', e.target.value),
               }}
             /> */}
-          </Skeleton>
-          <Skeleton variant="ironFish" isLoaded={!!data}>
-            <TextField
-              label="Blocks Per Message"
-              value={nodeSettings?.blocksPerMessage?.toString()}
-              InputProps={{
-                type: 'number',
-                onChange: e =>
-                  updateSettingValue('blocksPerMessage', e.target.value),
-              }}
-            />
-          </Skeleton>
-        </Grid>
-        <br />
-        <Flex gap="2rem">
-          <Skeleton w="50%" my="1rem" variant="ironFish" isLoaded={!!data}>
-            <FormControl display="flex" alignItems="center">
-              <Switch
-                size="md"
-                id="toggle-telemetry"
-                isChecked={nodeSettings?.enableTelemetry}
-                onChange={e =>
-                  updateSettingValue('enableTelemetry', e.target.checked)
-                }
-                mr="0.5rem"
+            </Skeleton>
+            <Skeleton variant="ironFish" isLoaded={!!data}>
+              <TextField
+                label="Blocks Per Message"
+                value={nodeSettings?.blocksPerMessage?.toString()}
+                InputProps={{
+                  type: 'number',
+                  onChange: e =>
+                    updateSettingValue('blocksPerMessage', e.target.value),
+                }}
               />
-              <FormLabel htmlFor="toggle-telemetry" mb="0">
-                {nodeSettings?.enableTelemetry
-                  ? 'Telemetry enabled'
-                  : 'Telemetry disabled'}
-              </FormLabel>
-            </FormControl>
-          </Skeleton>
-          <Flex w="50%" />
+            </Skeleton>
+          </Grid>
+          <br />
+          <Flex gap="2rem">
+            <Skeleton w="50%" my="1rem" variant="ironFish" isLoaded={!!data}>
+              <FormControl display="flex" alignItems="center">
+                <Switch
+                  size="md"
+                  id="toggle-telemetry"
+                  isChecked={nodeSettings?.enableTelemetry}
+                  onChange={e =>
+                    updateSettingValue('enableTelemetry', e.target.checked)
+                  }
+                  mr="0.5rem"
+                />
+                <FormLabel htmlFor="toggle-telemetry" mb="0">
+                  {nodeSettings?.enableTelemetry
+                    ? 'Telemetry enabled'
+                    : 'Telemetry disabled'}
+                </FormLabel>
+              </FormControl>
+            </Skeleton>
+            <Flex w="50%" />
+          </Flex>
+          <Flex my="1rem" gap="32px">
+            <Button
+              variant="primary"
+              size="large"
+              onClick={handleSaveSettings}
+              isDisabled={!loaded || hasNoChanges}
+            >
+              Save settings
+            </Button>
+            <Link
+              alignSelf="center"
+              as="span"
+              onClick={() => setOpenConfirmReset(true)}
+            >
+              <RepeatIcon marginRight="8px" />
+              <chakra.h4 display={'inline'}>Reset Node</chakra.h4>
+            </Link>
+          </Flex>
+          <Flex my="1rem" gap="32px"></Flex>
         </Flex>
-        <Flex my="1rem" gap="32px">
-          <Button
-            variant="primary"
-            size="large"
-            onClick={handleSaveSettings}
-            isDisabled={!loaded || hasNoChanges}
-          >
-            Save settings
-          </Button>
-        </Flex>
+        <Box>
+          <DetailsPanel>
+            <Information />
+          </DetailsPanel>
+        </Box>
       </Flex>
-      <Box>
-        <DetailsPanel>
-          <Information />
-        </DetailsPanel>
-      </Box>
-    </Flex>
+      <ConfirmModal
+        isOpen={openConfirmReset}
+        onClose={() => setOpenConfirmReset(false)}
+        onConfirm={() => {
+          handleResetNode()
+          setOpenConfirmReset(false)
+        }}
+        title="Reset Node"
+        description='By typing "RESET", you will lost any custom node settings and you will be prompted to resync the blockchain. Your account data will NOT be reset.'
+        validationText="RESET"
+        buttonText="Reset Node"
+      />
+    </>
   )
 }
 

--- a/types/IronfishManager/IIronfishManager.ts
+++ b/types/IronfishManager/IIronfishManager.ts
@@ -26,6 +26,8 @@ export enum IronfishManagerAction {
   STOP = 'stop',
   STOP_SYNCING = 'stopSyncing',
   SYNC = 'sync',
+  RESET_NODE = 'resetNode',
+  RESTART_APP = 'restartApp',
 }
 
 export interface IIronfishManager {
@@ -53,6 +55,8 @@ export interface IIronfishManager {
   getInternalConfig<T extends keyof InternalOptions>(
     option: T
   ): Promise<InternalOptions[T]>
+  resetNode: () => Promise<void>
+  restartApp: () => Promise<void>
 }
 
 export default IIronfishManager


### PR DESCRIPTION
## Summary:
- Adds a `ConfirmModal` component (will be reused for account deletion).
- Uses that component for confirming node reset.
- Updates `IronFishManager` to have `resetNode` method callable from frontend.
- onConfirm will reset the node and restart the app


https://github.com/iron-fish/node-app/assets/26990067/02034166-59b1-4eba-a38f-6f29473c8589





