### PR TITLE
fix(node-app): Fix offset in pagination for single record

### DIFF
--- a/electron/ironfish/TransactionManager.ts
+++ b/electron/ironfish/TransactionManager.ts
@@ -217,7 +217,7 @@ class TransactionManager
     let hasNext = false
 
     for await (const transaction of account.getTransactionsByTime()) {
-      if (i <= offset) {
+      if (i < offset) {
         i++
         continue
       }


### PR DESCRIPTION
## Description

The transaction list view does not show the first page correctly if there is a 0 offset in a single page for a single record.

If an account has one transaction:
* The loop will stream element
* The offset check will continue to the next iteration
* The stream won't have any records
* The transaction won't get returned to the caller

## Testing

### Before

![image](https://github.com/iron-fish/node-app/assets/5459049/4bb34530-176d-4ecb-8d6c-4a9870090f95)

### After

![image](https://github.com/iron-fish/node-app/assets/5459049/d672ba30-37dc-4944-85ad-ede96765ba57)
