### PR TITLE
feat(ifl-1094): view only account support

### DIFF
--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -161,19 +161,18 @@ class AccountManager
     const account: WalletAccount = accounts[accountIndex].serialize()
     account.balances = await this.balances(account.id)
     account.order = accountIndex
-    account.mnemonicPhrase = spendingKeyToWords(
-      account.spendingKey,
-      LanguageCode.English
-    ).split(' ')
-
+    account.mnemonicPhrase = account.spendingKey
+      ? spendingKeyToWords(account.spendingKey, LanguageCode.English).split(' ')
+      : null
+    account.viewOnly = !account.spendingKey
     return account
   }
 
-  async getMnemonicPhrase(id: string): Promise<string[]> {
+  async getMnemonicPhrase(id: string): Promise<string[] | null> {
     const account = this.node.wallet.getAccount(id)
-    return spendingKeyToWords(account.spendingKey, LanguageCode.English).split(
-      ' '
-    )
+    return account.spendingKey
+      ? spendingKeyToWords(account.spendingKey, LanguageCode.English).split(' ')
+      : null
   }
 
   async import(account: Omit<AccountValue, 'rescan'>): Promise<AccountValue> {
@@ -243,6 +242,7 @@ class AccountManager
         name: account.name,
         publicAddress: account.publicAddress,
         balances: await this.balances(account.id),
+        viewOnly: account.spendingKey === null,
         order: index,
       }))
     )

--- a/src/components/AccountsSelect.tsx
+++ b/src/components/AccountsSelect.tsx
@@ -12,23 +12,27 @@ interface AccountsSelectProps extends FlexProps {
   onSelectOption?: (account: CutAccount) => void
   showBalance?: boolean
   watchBalance?: boolean
+  includeViewOnly?: boolean
 }
 
 const getAccountOptions = (
   accounts: CutAccount[] = [],
-  showBalance: boolean
+  showBalance: boolean,
+  includeViewOnly: boolean
 ): OptionType[] => {
-  return accounts.map(account => ({
-    label: account.name,
-    value: account,
-    helperText: showBalance
-      ? formatOreToTronWithLanguage(
-          account?.balances?.default?.confirmed || BigInt(0)
-        ) +
-          ' ' +
-          account?.balances?.default?.asset?.name || ''
-      : truncateHash(account.publicAddress, 2, 4),
-  }))
+  return accounts
+    .filter(account => includeViewOnly || !account.viewOnly)
+    .map(account => ({
+      label: account.name,
+      value: account,
+      helperText: showBalance
+        ? formatOreToTronWithLanguage(
+            account?.balances?.default?.confirmed || BigInt(0)
+          ) +
+            ' ' +
+            account?.balances?.default?.asset?.name || ''
+        : truncateHash(account.publicAddress, 2, 4),
+    }))
 }
 
 const AccountsSelect: FC<AccountsSelectProps> = ({
@@ -36,6 +40,7 @@ const AccountsSelect: FC<AccountsSelectProps> = ({
   onSelectOption,
   showBalance = true,
   watchBalance = false,
+  includeViewOnly = false,
   ...props
 }) => {
   const [{ data, loaded }, reloadAccounts] = useAccounts()
@@ -50,7 +55,7 @@ const AccountsSelect: FC<AccountsSelectProps> = ({
   }, [loaded])
 
   const options = useMemo(
-    () => getAccountOptions(data, showBalance),
+    () => getAccountOptions(data, showBalance, includeViewOnly),
     [
       JSON.stringify(data, (key, value) =>
         typeof value === 'bigint' ? value.toString() : value

--- a/src/data/DemoAccountsManager.ts
+++ b/src/data/DemoAccountsManager.ts
@@ -402,6 +402,7 @@ class DemoAccountsManager implements IIronfishAccountManager {
             default: ACCOUNT_BALANCES[account.id][0],
             assets: ACCOUNT_BALANCES[account.id].slice(1),
           },
+          viewOnly: false,
           order: index,
         })).filter(
           account =>

--- a/src/routes/Accounts/AccountPreview.tsx
+++ b/src/routes/Accounts/AccountPreview.tsx
@@ -28,6 +28,7 @@ const AccountPreview: FC<CutAccount> = ({
   name,
   publicAddress,
   id,
+  viewOnly,
   balances,
 }) => {
   const navigate = useNavigate()
@@ -168,7 +169,7 @@ const AccountPreview: FC<CutAccount> = ({
                     <SendIcon />
                   </Icon>
                 }
-                isDisabled={!synced}
+                isDisabled={viewOnly || !synced}
               >
                 <h5>Send</h5>
               </Button>

--- a/src/routes/Accounts/AccountTabs/Keys.tsx
+++ b/src/routes/Accounts/AccountTabs/Keys.tsx
@@ -84,26 +84,28 @@ const AccountKeys: FC<AccountKeysProps> = ({ account, exportAccount }) => {
   return (
     <Flex mb="4rem">
       <Box w="37.25rem">
-        <MnemonicView
-          header={
-            <Flex gap="0.4375rem" mb="-0.4375rem" alignItems="center">
-              <h6>Mnemonic phrase</h6>
-              <CopyToClipboardButton
-                value={phrase?.join(' ')}
-                copyTooltipText="Copy to clipboard"
-                copiedTooltipText="Copied"
-              />
-            </Flex>
-          }
-          loaded={loaded}
-          value={phrase || []}
-          placeholder={''}
-          onChange={() => null}
-          isReadOnly={true}
-          mb="2rem"
-          wordsAmount={24}
-          showInfoIcon={false}
-        />
+        {phrase && (
+          <MnemonicView
+            header={
+              <Flex gap="0.4375rem" mb="-0.4375rem" alignItems="center">
+                <h6>Mnemonic phrase</h6>
+                <CopyToClipboardButton
+                  value={phrase?.join(' ')}
+                  copyTooltipText="Copy to clipboard"
+                  copiedTooltipText="Copied"
+                />
+              </Flex>
+            }
+            loaded={loaded}
+            value={phrase || []}
+            placeholder={''}
+            onChange={() => null}
+            isReadOnly={true}
+            mb="2rem"
+            wordsAmount={24}
+            showInfoIcon={false}
+          />
+        )}
         <Flex alignItems={'center'} gap="2rem">
           <SelectField
             label="Export format"

--- a/src/routes/Accounts/AccountTabs/Overview/OverviewBalance.tsx
+++ b/src/routes/Accounts/AccountTabs/Overview/OverviewBalance.tsx
@@ -67,8 +67,8 @@ const OverviewBalance: FC<OverviewBalanceProps> = ({ account }) => {
                     state: { accountId: account.id },
                   })
                 }
-                isDisabled={!synced}
-                disabled={!synced}
+                isDisabled={account.viewOnly || !synced}
+                disabled={account.viewOnly || !synced}
               >
                 <h5>Send</h5>
               </Button>

--- a/src/routes/Receive/ReceiveMoney.tsx
+++ b/src/routes/Receive/ReceiveMoney.tsx
@@ -128,6 +128,7 @@ const ReceiveMoney: FC = () => {
             accountId={account?.id || state?.accountId}
             onSelectOption={setAccount}
             mb="2rem"
+            includeViewOnly={true}
           />
           {/* Hide amount field while not clarified, should be removed or enabled when with API connection
            <TextField

--- a/types/Account.ts
+++ b/types/Account.ts
@@ -2,6 +2,7 @@ import { AccountValue } from '@ironfish/sdk'
 import AccountBalance from './AccountBalance'
 
 interface Account extends AccountValue {
+  viewOnly?: boolean
   balances?: {
     default: AccountBalance
     assets: AccountBalance[]

--- a/types/CutAccount.ts
+++ b/types/CutAccount.ts
@@ -7,6 +7,7 @@ interface CutAccount
     default: AccountBalance
     assets: AccountBalance[]
   }
+  viewOnly?: boolean
   order?: number
 }
 


### PR DESCRIPTION
## View only account support
- Fixes account details page with view only
- disables `Send` button for view only accounts in various places
- Removes view only accounts from send addresses 

<img width="1707" alt="Screenshot 2023-06-08 at 2 49 16 PM" src="https://github.com/iron-fish/node-app/assets/26990067/30e22d1c-3a7c-4697-b119-083c8b10d03d">
<img width="1663" alt="Screenshot 2023-06-08 at 2 49 21 PM" src="https://github.com/iron-fish/node-app/assets/26990067/75a00525-4ea3-42e2-af96-9947998ae68b">
<img width="1288" alt="Screenshot 2023-06-08 at 2 49 33 PM" src="https://github.com/iron-fish/node-app/assets/26990067/f8e8d019-2259-4c4e-8020-8f67682a5da8">
<img width="1457" alt="Screenshot 2023-06-08 at 2 49 47 PM" src="https://github.com/iron-fish/node-app/assets/26990067/0fcf580f-131d-4402-b0ea-da1be4293afe">

