### PR TITLE
fix(ifl-1075): display memo of non-change note if present

### DIFF
--- a/src/routes/Accounts/AccountTabs/Overview/SearchTransactions.tsx
+++ b/src/routes/Accounts/AccountTabs/Overview/SearchTransactions.tsx
@@ -122,7 +122,8 @@ const SearchTransactions: FC<SearchTransactionsProps> = ({ address }) => {
                 <chakra.h5>
                   "
                   {transaction.outputs?.at(0)?.memo ||
-                    transaction.inputs?.at(0)?.memo}
+                    transaction.inputs?.at(0)?.memo ||
+                    transaction.outputs?.at(1)?.memo}
                   "
                 </chakra.h5>
               ),


### PR DESCRIPTION
Previously if change note is present, it will only display the memo of that note (if a change note is present). This tries to grab non-change note if no other memo is found.
<img width="1677" alt="Screenshot 2023-06-09 at 11 49 49 AM" src="https://github.com/iron-fish/node-app/assets/26990067/ac32815e-45df-4db4-b00c-eb4c58b9251f">
