### PR TITLE
Fix migration ID and name loading in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-scripts": "^5.0.1",
     "react-spring": "9.5.2",
     "stream-browserify": "^3.0.0",
+    "string-replace-loader": "3.1.0",
     "style-loader": "^3.0.0",
     "tar": "^6.1.13",
     "ts-loader": "^9.2.2",

--- a/webpack/common/rules.js
+++ b/webpack/common/rules.js
@@ -1,4 +1,20 @@
 module.exports = [
+  {
+    test: /@ironfish\/sdk\/build\/src\/migrations\/data\/.*\.js$/,
+    loader: 'string-replace-loader',
+    options: {
+      search: '__filename',
+      replace(match, p1, offset, string) {
+        // Fixes migration files in the SDK relying on __filename to determine the ID and name of the migration.
+        // The migration filename is currently only used to extract the ID and name of the migration, not to read the
+        // actual file.
+        // After bundling, __filename will resolve to the webpack-bundled file's name,
+        // something like index.js, so we can avoid this by replacing __filename with the original filename.
+        return `'${this.resource.toString()}'`
+      },
+      flags: 'g',
+    },
+  },
   // Add support for native node modules
   {
     // We're specifying native_modules in the test because the asset relocator loader generates a

--- a/yarn.lock
+++ b/yarn.lock
@@ -15540,6 +15540,14 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
+string-replace-loader@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-3.1.0.tgz#11ac6ee76bab80316a86af358ab773193dd57a4f"
+  integrity sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
The migrations load their ID and name dynamically using `__fileName`. This doesn't work when the files are bundled together using webpack, and it's not easy to separate webpack from electron-forge, so for now we can overwrite `__filename` in the migration files with the original filename.

We should probably consider fixing this in the SDK to embed the name and ID directly in the migrations rather than loading them dynamically, but this will work for now without an SDK deployment.