### PR TITLE
feat: Add view-only chip indicator

### DIFF
--- a/src/components/ViewOnlyChip/ViewOnlyChip.tsx
+++ b/src/components/ViewOnlyChip/ViewOnlyChip.tsx
@@ -1,0 +1,45 @@
+import {
+  Tooltip,
+  useColorMode,
+  Text,
+  HStack,
+  NAMED_COLORS,
+} from '@ironfish/ui-kit'
+
+function Icon() {
+  return (
+    <svg width={14} height={15} fill="none">
+      <path
+        fill="currentColor"
+        d="M6.55 10.833h1v-4h-1v4ZM7 5.6a.541.541 0 0 0 .392-.153.508.508 0 0 0 .158-.38.557.557 0 0 0-.158-.404A.524.524 0 0 0 7 4.5a.525.525 0 0 0-.392.163.557.557 0 0 0-.158.404c0 .15.053.277.158.38A.54.54 0 0 0 7 5.6Zm.004 8.567c-.919 0-1.783-.175-2.591-.525a6.774 6.774 0 0 1-2.121-1.434 6.77 6.77 0 0 1-1.434-2.122 6.465 6.465 0 0 1-.525-2.594c0-.92.175-1.785.525-2.595a6.67 6.67 0 0 1 1.434-2.114 6.842 6.842 0 0 1 2.122-1.425A6.465 6.465 0 0 1 7.008.833c.92 0 1.785.175 2.595.525a6.74 6.74 0 0 1 2.114 1.425c.6.6 1.075 1.306 1.425 2.117a6.48 6.48 0 0 1 .525 2.596c0 .919-.175 1.783-.525 2.591a6.808 6.808 0 0 1-1.425 2.118A6.73 6.73 0 0 1 9.6 13.64a6.447 6.447 0 0 1-2.596.528Zm.004-1c1.572 0 2.909-.553 4.009-1.659 1.1-1.105 1.65-2.444 1.65-4.016 0-1.573-.55-2.909-1.647-4.009-1.098-1.1-2.438-1.65-4.02-1.65-1.567 0-2.903.55-4.008 1.647C1.886 4.578 1.333 5.918 1.333 7.5c0 1.567.553 2.903 1.659 4.008 1.105 1.106 2.444 1.659 4.016 1.659Z"
+      />
+    </svg>
+  )
+}
+
+export function ViewOnlyChip() {
+  const isLightMode = useColorMode().colorMode === 'light'
+  return (
+    <Tooltip
+      label="View only accounts cannot initiate transactions"
+      placement="top"
+    >
+      <HStack
+        alignItems="center"
+        bg={isLightMode ? NAMED_COLORS.LIGHTER_GREY : NAMED_COLORS.DARKER_GREY}
+        color={isLightMode ? NAMED_COLORS.GREY : NAMED_COLORS.PALE_GREY}
+        spacing={1}
+        borderRadius="full"
+        border="1px solid transparent"
+        px="8px"
+        py="2px"
+        _hover={{
+          borderColor: isLightMode ? NAMED_COLORS.GREY : NAMED_COLORS.PALE_GREY,
+        }}
+      >
+        <Icon />
+        <Text fontSize="12px">View Only</Text>
+      </HStack>
+    </Tooltip>
+  )
+}

--- a/src/data/DemoAccountsManager.ts
+++ b/src/data/DemoAccountsManager.ts
@@ -20,7 +20,11 @@ import { ACCOUNT_SETTINGS } from './DemoAccountSettingsManager'
 import uniqueId from 'lodash/uniqueId'
 import EventType from 'Types/EventType'
 
-export const DEMO_ACCOUNTS: AccountValue[] = [
+type DemoAccount = AccountValue & {
+  viewOnly?: boolean
+}
+
+export const DEMO_ACCOUNTS: DemoAccount[] = [
   {
     id: 'jwbdcLHnLgvnL5oZl554mRWiaiAxmhtWt0dN4djPKntVt5EV443wRMxYzSXX4nX8',
     name: 'Primary Account',
@@ -50,6 +54,7 @@ export const DEMO_ACCOUNTS: AccountValue[] = [
     version: 1,
     viewKey: nanoid(64),
     createdAt: null,
+    viewOnly: true,
   },
   {
     id: 'q1Pr8GLyskDXbBSUM3DMGOOlrNWv5RFloVr57YGxWrh98Afwz5nDCL1nbMIxfhA7',

--- a/src/routes/Account/AccountDetails.tsx
+++ b/src/routes/Account/AccountDetails.tsx
@@ -19,6 +19,7 @@ import BackButtonLink from 'Components/BackButtonLink'
 import useAccount from 'Hooks/accounts/useAccount'
 import AccountSettings from './Settings/Settings'
 import { Container } from './Shared/Container'
+import { ViewOnlyChip } from 'Components/ViewOnlyChip/ViewOnlyChip'
 
 export default function AccountDetails() {
   const location = useLocation()
@@ -39,8 +40,9 @@ export default function AccountDetails() {
       </Container>
       {loaded && (
         <>
-          <Container display="flex" alignItems="end" mb="0.5rem">
-            <chakra.h2 mr="1rem">{account.name}</chakra.h2>
+          <Container display="flex" alignItems="center" mb="0.5rem" gap={3}>
+            <chakra.h2 pb="0.15rem">{account.name}</chakra.h2>
+            {account.viewOnly && <ViewOnlyChip />}
             <CopyValueToClipboard
               label={truncateHash(account?.publicAddress, 3)}
               labelProps={{
@@ -50,7 +52,6 @@ export default function AccountDetails() {
               copyTooltipText="Copy to clipboard"
               copiedTooltipText="Copied"
               containerProps={{
-                pb: '0.45rem',
                 color: NAMED_COLORS.GREY,
                 _dark: {
                   color: NAMED_COLORS.PALE_GREY,

--- a/src/routes/Accounts/AccountPreview.tsx
+++ b/src/routes/Accounts/AccountPreview.tsx
@@ -9,6 +9,7 @@ import {
   NAMED_COLORS,
   chakra,
   CopyValueToClipboard,
+  HStack,
 } from '@ironfish/ui-kit'
 import SendIcon from 'Svgx/send'
 import Receive from 'Svgx/receive'
@@ -22,6 +23,7 @@ import { accountGradientByOrder } from 'Utils/accountGradientByOrder'
 import { formatOreToTronWithLanguage } from 'Utils/number'
 import AssetsBadge from 'Components/AssetsBadge'
 import WarningMessage from 'Components/WarningMessage'
+import { ViewOnlyChip } from 'Components/ViewOnlyChip/ViewOnlyChip'
 
 const AccountPreview: FC<CutAccount> = ({
   order = 0,
@@ -119,7 +121,10 @@ const AccountPreview: FC<CutAccount> = ({
           <HexFish style={{ height: '2rem' }} />
         </Flex>
         <Box>
-          <chakra.h5 pt="0.25rem">{name}</chakra.h5>
+          <HStack spacing="3">
+            <chakra.h5 pt="0.25rem">{name}</chakra.h5>
+            {viewOnly && <ViewOnlyChip />}
+          </HStack>
           <chakra.h3 p="0.25rem 0">
             {formatOreToTronWithLanguage(
               balances?.default?.confirmed || BigInt(0)

--- a/src/routes/Accounts/Accounts.tsx
+++ b/src/routes/Accounts/Accounts.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useMemo, useEffect, useCallback } from 'react'
+import { FC, useState, useMemo, useEffect } from 'react'
 import {
   Box,
   Button,
@@ -20,7 +20,6 @@ import CreateAccount from 'Routes/Onboarding/CreateAccount'
 import SortType from 'Types/SortType'
 import { formatOreToTronWithLanguage } from 'Utils/number'
 import EmptyOverview from 'Components/EmptyOverview'
-import SyncWarningMessage from 'Components/SyncWarningMessage'
 
 interface ActionButtonsProps {
   reloadAccounts: () => void


### PR DESCRIPTION
Adds "View Only" chip + tooltip indicator for view-only accounts.

<img width="1424" alt="Screenshot 2023-06-14 at 4 47 05 PM" src="https://github.com/iron-fish/node-app/assets/3639170/101d7a72-4135-4218-a651-b0398c3c9184">
<img width="1424" alt="Screenshot 2023-06-14 at 4 47 10 PM" src="https://github.com/iron-fish/node-app/assets/3639170/ec1a342d-69fa-45c7-a77b-6c4fbc5c996d">
<img width="1424" alt="Screenshot 2023-06-14 at 4 47 18 PM" src="https://github.com/iron-fish/node-app/assets/3639170/15f4161d-fa58-4404-9171-94ea91cabfa6">
<img width="1424" alt="Screenshot 2023-06-14 at 4 47 24 PM" src="https://github.com/iron-fish/node-app/assets/3639170/dd2c39f7-5326-4da6-8e42-c2e35b0d4abc">
