### PR TITLE
fix(node-app): Show total for $IRON properly in confirmation modal

### DIFF
--- a/src/routes/Send/SendFlow/ConfirmStep.tsx
+++ b/src/routes/Send/SendFlow/ConfirmStep.tsx
@@ -165,15 +165,23 @@ const ConfirmStep: FC<StepProps> = ({
             title="Total:"
             value={
               <Flex direction="column">
-                <chakra.h4 textAlign="end">
-                  {formatOreToTronWithLanguage(amount)}
-                  &nbsp;{asset.name}
-                </chakra.h4>
-                {asset.id !== feeAsset.id && (
+                {asset.id === feeAsset.id && (
                   <chakra.h4 textAlign="end">
-                    {formatOreToTronWithLanguage(fee)}
-                    &nbsp;{feeAsset.name}
+                    {formatOreToTronWithLanguage(amount + fee)}
+                    &nbsp;{asset.name}
                   </chakra.h4>
+                )}
+                {asset.id !== feeAsset.id && (
+                  <>
+                    <chakra.h4 textAlign="end">
+                      {formatOreToTronWithLanguage(amount)}
+                      &nbsp;{asset.name}
+                    </chakra.h4>
+                    <chakra.h4 textAlign="end">
+                      {formatOreToTronWithLanguage(fee)}
+                      &nbsp;{feeAsset.name}
+                    </chakra.h4>
+                  </>
                 )}
               </Flex>
             }

--- a/src/routes/Send/SendFlow/ConfirmStep.tsx
+++ b/src/routes/Send/SendFlow/ConfirmStep.tsx
@@ -178,7 +178,7 @@ const ConfirmStep: FC<StepProps> = ({
                       &nbsp;{asset.name}
                     </chakra.h4>
                     <chakra.h4 textAlign="end">
-                      {formatOreToTronWithLanguage(fee)}
+                      +{formatOreToTronWithLanguage(fee)}
                       &nbsp;{feeAsset.name}
                     </chakra.h4>
                   </>


### PR DESCRIPTION
### Native Asset

![Screenshot from 2023-06-16 14-23-40](https://github.com/iron-fish/node-app/assets/5459049/89d834f5-bb10-4ccd-8dcc-8c9550cfb12d)

### Custom Minted Asset

![image](https://github.com/iron-fish/node-app/assets/5459049/1bcc8983-fbb7-42a0-91aa-f0c4ac8c0252)

