### PR TITLE
feat(ifl-1096): block explorer links in transaction overview

### DIFF
--- a/electron/contextBridge/IronfishManagerContext.ts
+++ b/electron/contextBridge/IronfishManagerContext.ts
@@ -82,6 +82,10 @@ class IronfishManagerContext implements IIronfishManager {
   restartApp = () => {
     return invoke('ironfish-manager', IronfishManagerAction.RESTART_APP)
   }
+
+  openLink = (url: string) => {
+    return invoke('ironfish-manager', IronfishManagerAction.OPEN_LINK, url)
+  }
 }
 
 export default new IronfishManagerContext()

--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -33,7 +33,7 @@ import EventType from 'Types/EventType'
 import { ERROR_MESSAGES } from '../utils/constants'
 import sendMessageToRender from '../utils/sendMessageToRender'
 import { WorkerMessageType } from '@ironfish/sdk/build/src/workerPool/tasks/workerMessage'
-import { app } from 'electron'
+import { app, shell } from 'electron'
 
 export class IronFishManager implements IIronfishManager {
   protected initStatus: IronFishInitStatus = IronFishInitStatus.NOT_STARTED
@@ -440,6 +440,10 @@ export class IronFishManager implements IIronfishManager {
       accounts: accountsInfo,
     }
     return Promise.resolve(status)
+  }
+
+  async openLink(url: string): Promise<void> {
+    return Promise.resolve(shell.openExternal(url))
   }
 
   peers(): Promise<Peer[]> {

--- a/src/data/DemoDataManager.ts
+++ b/src/data/DemoDataManager.ts
@@ -161,6 +161,10 @@ class DemoDataManager implements IIronfishManager {
   async restartApp(): Promise<void> {
     return
   }
+
+  async openLink(url: string): Promise<void> {
+    return
+  }
 }
 
 export default DemoDataManager

--- a/src/routes/Transaction/TransactionOverview.tsx
+++ b/src/routes/Transaction/TransactionOverview.tsx
@@ -9,7 +9,9 @@ import {
   Skeleton,
   Grid,
   useIronToast,
+  Link,
 } from '@ironfish/ui-kit'
+import { ExternalLinkIcon } from '@chakra-ui/icons'
 import size from 'byte-size'
 import { ROUTES } from '..'
 import BackButtonLink from 'Components/BackButtonLink'
@@ -30,6 +32,7 @@ import WalletCommonTable from 'Components/WalletCommonTable'
 import InfoBadge from 'Components/InfoBadge'
 import AssetsAmountPreview from 'Components/AssetsAmountPreview'
 import { formatDate } from 'Utils/formatDate'
+import { BLOCK_EXPLORER_URL } from 'Utils/constants'
 
 interface Card {
   render: (tx: Transaction) => ReactNode
@@ -82,15 +85,27 @@ const CARDS: Card[] = [
   {
     render: (tx: Transaction) =>
       tx?.blockHash ? (
-        <CopyValueToClipboard
-          label={truncateHash(tx?.blockHash || '', 2, 4)}
-          value={tx?.blockHash || ''}
-          iconButtonProps={{
-            color: NAMED_COLORS.GREY,
-          }}
-          copyTooltipText={'Copy block hash'}
-          copiedTooltipText={'Block hash copied'}
-        />
+        <>
+          <CopyValueToClipboard
+            label={truncateHash(tx?.blockHash || '', 2, 4)}
+            value={tx?.blockHash || ''}
+            iconButtonProps={{
+              color: NAMED_COLORS.GREY,
+            }}
+            copyTooltipText={'Copy block hash'}
+            copiedTooltipText={'Block hash copied'}
+          />
+          <Link
+            onClick={() =>
+              window.IronfishManager.openLink(
+                `${BLOCK_EXPLORER_URL}/blocks/${tx.blockHash}`
+              )
+            }
+            color={NAMED_COLORS.LIGHT_BLUE}
+          >
+            View Block Explorer <ExternalLinkIcon />
+          </Link>
+        </>
       ) : (
         'n/a'
       ),
@@ -99,15 +114,27 @@ const CARDS: Card[] = [
   },
   {
     render: (tx: Transaction) => (
-      <CopyValueToClipboard
-        label={truncateHash(tx?.hash || '', 2, 4)}
-        iconButtonProps={{
-          color: NAMED_COLORS.GREY,
-        }}
-        value={tx?.hash || ''}
-        copyTooltipText={'Copy Transaction hash'}
-        copiedTooltipText={'Transaction hash copied'}
-      />
+      <>
+        <CopyValueToClipboard
+          label={truncateHash(tx?.hash || '', 2, 4)}
+          iconButtonProps={{
+            color: NAMED_COLORS.GREY,
+          }}
+          value={tx?.hash || ''}
+          copyTooltipText={'Copy Transaction hash'}
+          copiedTooltipText={'Transaction hash copied'}
+        />
+        <Link
+          onClick={() =>
+            window.IronfishManager.openLink(
+              `${BLOCK_EXPLORER_URL}/transaction/${tx.hash}`
+            )
+          }
+          color={NAMED_COLORS.LIGHT_BLUE}
+        >
+          View Block Explorer <ExternalLinkIcon />
+        </Link>
+      </>
     ),
     label: 'Transaction Hash',
     icon: DifficultyIcon,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const BLOCK_EXPLORER_URL = 'https://explorer.ironfish.network'

--- a/types/IronfishManager/IIronfishManager.ts
+++ b/types/IronfishManager/IIronfishManager.ts
@@ -28,6 +28,7 @@ export enum IronfishManagerAction {
   SYNC = 'sync',
   RESET_NODE = 'resetNode',
   RESTART_APP = 'restartApp',
+  OPEN_LINK = 'openLink',
 }
 
 export interface IIronfishManager {
@@ -57,6 +58,7 @@ export interface IIronfishManager {
   ): Promise<InternalOptions[T]>
   resetNode: () => Promise<void>
   restartApp: () => Promise<void>
+  openLink: (url: string) => Promise<void>
 }
 
 export default IIronfishManager


### PR DESCRIPTION
Adds block explorer links to
1. Transaction
2. Block

https://github.com/iron-fish/node-app/assets/26990067/0a3e3b80-3545-4dcf-a506-d32a19e7e97c

