### PR TITLE
chore(ifl-1131): migrate only if on testnet

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -237,8 +237,8 @@ export class IronFishManager implements IIronfishManager {
     await this.checkForMigrations()
 
     if (
-      (this.sdk.internal.get('networkId') !== 1 ||
-        this.node.config.get('networkId') !== 1) &&
+      (this.sdk.internal.get('networkId') === 0 ||
+        this.node.config.get('networkId') === 0) &&
       (app.isPackaged || process.env.ENABLE_RESET)
     ) {
       log.log(


### PR DESCRIPTION
Instead of migrating if _not_ on mainnet, migrate _only_ testnet -> mainnet