### PR TITLE
fix(node-app): `.json` extension added only if JSON export

### DIFF
--- a/src/routes/Account/Keys/Keys.tsx
+++ b/src/routes/Account/Keys/Keys.tsx
@@ -72,7 +72,9 @@ const AccountKeys: FC<AccountKeysProps> = ({ account, exportAccount }) => {
         const file = new Blob([exportedAccount], { type: 'text/plain' })
         const element = document.createElement('a')
         element.href = URL.createObjectURL(file)
-        element.download = account.name + '.json'
+        element.download = exportType.value
+          ? account.name
+          : `${account.name}.json`
         document.body.appendChild(element)
         element.click()
         document.removeChild(element)


### PR DESCRIPTION
The JSON extension is only needed if a JSON export is selected for the keys. Otherwise, omit the extension and let the downloader handle.