### PR TITLE
fix(node-app): Don't automatically set telemetry to true

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -228,12 +228,6 @@ export class IronFishManager implements IIronfishManager {
       autoSeed: true,
     })
 
-    const isTelemetryEnabled = this.node.config.isSet('enableTelemetry')
-    if (!isTelemetryEnabled) {
-      this.node.config.set('enableTelemetry', true)
-      this.node.config.save()
-    }
-
     await this.checkForMigrations()
 
     if (


### PR DESCRIPTION
If a data directory does not contain `enableTelemetry`, the application will set it to true when initializing. We shouldn't do that.