### PR TITLE
fix: Update copy on Reset Node modal

### DIFF
--- a/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
+++ b/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
@@ -234,7 +234,7 @@ const NodeSettings: FC = () => {
           setOpenConfirmReset(false)
         }}
         title="Reset Node"
-        description='By typing "RESET", you will lost any custom node settings and you will be prompted to resync the blockchain. Your account data will NOT be reset.'
+        description={`By typing "RESET", you'll lose any custom settings associated with your node and you'll be prompted to re-sync with the blockchain. Your account data will not be reset.`}
         validationText="RESET"
         buttonText="Reset Node"
       />


### PR DESCRIPTION
Updates the copy on the Reset Node modal to what's on the Linear ticket.