### PR TITLE
fix: Don't check for updates to render updates page + add latest version download link

### DIFF
--- a/electron/common/UpdateManager.ts
+++ b/electron/common/UpdateManager.ts
@@ -19,9 +19,13 @@ class UpdateManager implements IUpdateManager {
   }
 
   initialize: () => Promise<void> = () => {
-    this.url = `${this.serverUrl}/update/${
-      process.platform
-    }/${app.getVersion()}`
+    let platform: string = process.platform
+
+    if (process.arch === 'arm64') {
+      platform += '_arm64'
+    }
+
+    this.url = `${this.serverUrl}/update/${platform}/${app.getVersion()}`
 
     if (app.isPackaged) {
       autoUpdater.setFeedURL({ url: this.url })
@@ -55,8 +59,9 @@ class UpdateManager implements IUpdateManager {
   }
 
   checkUpdates: () => Promise<UpdateStatus> = () => {
-    app.isPackaged && autoUpdater.checkForUpdates()
-    if (!app.isPackaged) {
+    if (app.isPackaged) {
+      autoUpdater.checkForUpdates()
+    } else {
       this.status.hasUpdates = false //set to true to check how modal window looks
     }
     return Promise.resolve(this.status)
@@ -124,6 +129,10 @@ class UpdateManager implements IUpdateManager {
       }
       return []
     }
+  }
+
+  getVersion: () => Promise<string> = async () => {
+    return app.getVersion()
   }
 }
 

--- a/electron/common/UpdateManager.ts
+++ b/electron/common/UpdateManager.ts
@@ -134,6 +134,20 @@ class UpdateManager implements IUpdateManager {
   getVersion: () => Promise<string> = async () => {
     return app.getVersion()
   }
+
+  getDownloadLinkForPlatform: () => Promise<string | null> = async () => {
+    let platform: string = process.platform
+
+    if (platform === 'darwin') {
+      platform = 'dmg'
+    }
+
+    if (process.arch === 'arm64') {
+      platform += '_arm64'
+    }
+
+    return `${this.serverUrl}/download/${platform}`
+  }
 }
 
 const instance = new UpdateManager()

--- a/electron/contextBridge/UpdateManagerContext.ts
+++ b/electron/contextBridge/UpdateManagerContext.ts
@@ -38,6 +38,9 @@ class UpdateManagerContext implements IUpdateManager {
   getNewVersions: () => Promise<string[]> = () => {
     return invoke('update-manager', UpdateManagerAction.GET_VERSIONS_BEFORE)
   }
+  getVersion: () => Promise<string> = () => {
+    return invoke('update-manager', UpdateManagerAction.GET_VERSION)
+  }
 }
 
 export default new UpdateManagerContext()

--- a/electron/contextBridge/UpdateManagerContext.ts
+++ b/electron/contextBridge/UpdateManagerContext.ts
@@ -41,6 +41,12 @@ class UpdateManagerContext implements IUpdateManager {
   getVersion: () => Promise<string> = () => {
     return invoke('update-manager', UpdateManagerAction.GET_VERSION)
   }
+  getDownloadLinkForPlatform: () => Promise<string> = () => {
+    return invoke(
+      'update-manager',
+      UpdateManagerAction.GET_DOWNLOAD_LINK_FOR_PLATFORM
+    )
+  }
 }
 
 export default new UpdateManagerContext()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-app",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Iron Fish Node App",
   "main": ".webpack/main",
   "repository": "https://github.com/iron-fish/node-app",

--- a/src/data/DemoUpdateManager.ts
+++ b/src/data/DemoUpdateManager.ts
@@ -246,6 +246,14 @@ class DemoUpdateManager implements IUpdateManager {
       }, 500)
     )
   }
+
+  getVersion: () => Promise<string> = async () => {
+    return new Promise(resolve =>
+      setTimeout(() => {
+        resolve(this.status.version)
+      }, 500)
+    )
+  }
 }
 
 export default DemoUpdateManager

--- a/src/data/DemoUpdateManager.ts
+++ b/src/data/DemoUpdateManager.ts
@@ -254,6 +254,14 @@ class DemoUpdateManager implements IUpdateManager {
       }, 500)
     )
   }
+
+  getDownloadLinkForPlatform: () => Promise<string> = async () => {
+    return new Promise(resolve =>
+      setTimeout(() => {
+        resolve('/')
+      }, 500)
+    )
+  }
 }
 
 export default DemoUpdateManager

--- a/src/providers/ReleaseNotesProvider.tsx
+++ b/src/providers/ReleaseNotesProvider.tsx
@@ -37,17 +37,18 @@ const ReleaseNotesProvider: FC<{ children: ReactNode }> = ({ children }) => {
     useAsyncDataWrapper<UpdateReleaseNotesResponse>()
 
   useEffect(() => {
-    promiseWrapper(
-      window.UpdateManager.checkUpdates().then(status => {
-        return window.UpdateManager.notes(undefined, 100).then(response => ({
-          ...response,
-          data: response.data.map(note => ({
-            ...note,
-            isNew: isNewVersion(status.version, note.version),
-          })),
-        }))
-      })
-    )
+    const doFetch = async () => {
+      const version = await window.UpdateManager.getVersion()
+      const notes = await window.UpdateManager.notes(undefined, 100)
+      return {
+        ...notes,
+        data: notes.data.map(note => ({
+          ...note,
+          isNew: isNewVersion(version, note.version),
+        })),
+      }
+    }
+    promiseWrapper(doFetch())
   }, [])
 
   const value = {

--- a/src/routes/Updates/Updates.tsx
+++ b/src/routes/Updates/Updates.tsx
@@ -21,6 +21,34 @@ interface ReleaseNoteProps {
   isLatest?: boolean
 }
 
+function useLatestVersionDownloadLink({
+  isLatest,
+  isNew,
+}: {
+  isLatest?: boolean
+  isNew?: boolean
+}) {
+  const [downloadLink, setDownloadLink] = useState(null)
+  const shouldFetch = isLatest && isNew
+
+  useEffect(() => {
+    const getDownloadLink = async () => {
+      if (!shouldFetch) return
+
+      const link = await window.UpdateManager.getDownloadLinkForPlatform()
+
+      // If there is no latest download, the server responds with "/".
+      // Adding !link to be extra safe...
+      if (!link || link.length <= 1) return
+
+      setDownloadLink(link)
+    }
+    getDownloadLink()
+  }, [shouldFetch])
+
+  return downloadLink
+}
+
 const ReleaseNoteItem: FC<ReleaseNoteProps> = ({
   note,
   setIntersectionId,
@@ -42,6 +70,11 @@ const ReleaseNoteItem: FC<ReleaseNoteProps> = ({
 
     return () => observer.disconnect()
   }, [])
+
+  const downloadLink = useLatestVersionDownloadLink({
+    isLatest,
+    isNew: note.isNew,
+  })
 
   return (
     <Box ref={ref} w="100%" my="2rem" id={note.version}>
@@ -87,15 +120,15 @@ const ReleaseNoteItem: FC<ReleaseNoteProps> = ({
         >
           Read more
         </Link>
-        {isLatest && note.isNew && (
+        {downloadLink && (
           <Link
             color={NAMED_COLORS.LIGHT_BLUE}
             _hover={{ opacity: '0.7' }}
             as="a"
-            href={`https://github.com/iron-fish/node-app/releases/tag/${note.version}`}
+            href={downloadLink}
             target="_blank"
           >
-            View Download Options
+            Download Latest Version
           </Link>
         )}
       </Flex>

--- a/src/routes/Updates/Updates.tsx
+++ b/src/routes/Updates/Updates.tsx
@@ -18,9 +18,14 @@ import EmptyOverview from 'Components/EmptyOverview'
 interface ReleaseNoteProps {
   note: ReleaseNote
   setIntersectionId: (id: string) => void
+  isLatest?: boolean
 }
 
-const ReleaseNoteItem: FC<ReleaseNoteProps> = ({ note, setIntersectionId }) => {
+const ReleaseNoteItem: FC<ReleaseNoteProps> = ({
+  note,
+  setIntersectionId,
+  isLatest,
+}) => {
   const ref = useRef()
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -72,7 +77,7 @@ const ReleaseNoteItem: FC<ReleaseNoteProps> = ({ note, setIntersectionId }) => {
       <Box w="100%" maxH="3rem" h="min-content" overflow="hidden" mb="1rem">
         <ReactMarkdown>{note.notes}</ReactMarkdown>
       </Box>
-      <Box>
+      <Flex gap="2rem">
         <Link
           color={NAMED_COLORS.LIGHT_BLUE}
           _hover={{ opacity: '0.7' }}
@@ -82,7 +87,18 @@ const ReleaseNoteItem: FC<ReleaseNoteProps> = ({ note, setIntersectionId }) => {
         >
           Read more
         </Link>
-      </Box>
+        {isLatest && note.isNew && (
+          <Link
+            color={NAMED_COLORS.LIGHT_BLUE}
+            _hover={{ opacity: '0.7' }}
+            as="a"
+            href="https://www.google.com"
+            target="_blank"
+          >
+            View Download Options
+          </Link>
+        )}
+      </Flex>
     </Box>
   )
 }
@@ -120,6 +136,8 @@ const UpdateList: FC = () => {
     )
   }
 
+  console.log(data?.data)
+
   return (
     <Flex justifyContent="space-between">
       <Flex direction="column" w="calc(100% - 13rem)">
@@ -130,6 +148,7 @@ const UpdateList: FC = () => {
                 key={note.version}
                 note={note}
                 setIntersectionId={handleVisibleTagChange}
+                isLatest={index === 0}
               />
             ) : (
               <Skeleton

--- a/src/routes/Updates/Updates.tsx
+++ b/src/routes/Updates/Updates.tsx
@@ -92,7 +92,7 @@ const ReleaseNoteItem: FC<ReleaseNoteProps> = ({
             color={NAMED_COLORS.LIGHT_BLUE}
             _hover={{ opacity: '0.7' }}
             as="a"
-            href="https://www.google.com"
+            href={`https://github.com/iron-fish/node-app/releases/tag/${note.version}`}
             target="_blank"
           >
             View Download Options

--- a/src/routes/Updates/Updates.tsx
+++ b/src/routes/Updates/Updates.tsx
@@ -136,8 +136,6 @@ const UpdateList: FC = () => {
     )
   }
 
-  console.log(data?.data)
-
   return (
     <Flex justifyContent="space-between">
       <Flex direction="column" w="calc(100% - 13rem)">

--- a/types/IUpdateManager.ts
+++ b/types/IUpdateManager.ts
@@ -40,6 +40,7 @@ export enum UpdateManagerAction {
   NOTES = 'notes',
   NOTE = 'note',
   GET_VERSIONS_BEFORE = 'getNewVersions',
+  GET_VERSION = 'getVersion',
 }
 
 export interface IUpdateManager {
@@ -51,4 +52,5 @@ export interface IUpdateManager {
   notes: (after?: string, limit?: number) => Promise<UpdateReleaseNotesResponse>
   note: (version: string) => Promise<ReleaseNote>
   getNewVersions: () => Promise<string[]>
+  getVersion: () => Promise<string>
 }

--- a/types/IUpdateManager.ts
+++ b/types/IUpdateManager.ts
@@ -41,6 +41,7 @@ export enum UpdateManagerAction {
   NOTE = 'note',
   GET_VERSIONS_BEFORE = 'getNewVersions',
   GET_VERSION = 'getVersion',
+  GET_DOWNLOAD_LINK_FOR_PLATFORM = 'getDownloadLinkForPlatform',
 }
 
 export interface IUpdateManager {
@@ -53,4 +54,5 @@ export interface IUpdateManager {
   note: (version: string) => Promise<ReleaseNote>
   getNewVersions: () => Promise<string[]>
   getVersion: () => Promise<string>
+  getDownloadLinkForPlatform: () => Promise<string>
 }


### PR DESCRIPTION
- Adds `"_arm64"` to the platform sent to the update server if on an arm64 architecture.
- Updates the ReleaseNotesProvider so that it doesn't rely on calling `checkForUpdates()` in order to get the latest release notes.
- On the updates page, if the user is on an old version, it adds a link to download the latest version on the latest release notes tag.

![image](https://github.com/iron-fish/node-app/assets/3639170/1b377878-9411-4ec0-b7d7-c364572a7e62)

