### PR TITLE
feat(node-app): Remove loading spinner from `Sync from Peers`

### DIFF
--- a/src/components/Snapshot/SnapshotDownloadModal.tsx
+++ b/src/components/Snapshot/SnapshotDownloadModal.tsx
@@ -103,9 +103,7 @@ const SnapshotDownloadModal: FC<
             <Button
               variant="primary"
               size="medium"
-              disabled={loading}
               onClick={handleSyncing}
-              leftIcon={loading ? <Spinner /> : null}
             >
               Sync from Peers
             </Button>

--- a/src/components/Snapshot/SnapshotDownloadModal.tsx
+++ b/src/components/Snapshot/SnapshotDownloadModal.tsx
@@ -100,11 +100,7 @@ const SnapshotDownloadModal: FC<
             >
               Download Snapshot
             </Button>
-            <Button
-              variant="primary"
-              size="medium"
-              onClick={handleSyncing}
-            >
+            <Button variant="primary" size="medium" onClick={handleSyncing}>
               Sync from Peers
             </Button>
           </ModalFooter>


### PR DESCRIPTION
There's no loading state associated with this.