### PR TITLE
fix(Mac OS): Re-open window when clicking task bar icon

### DIFF
--- a/electron/common/index.ts
+++ b/electron/common/index.ts
@@ -94,6 +94,8 @@ app.on('ready', () => createWindow())
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', async () => {
+  mainWindow = null
+
   if (process.platform !== 'darwin') {
     app.quit()
   }
@@ -102,6 +104,7 @@ app.on('window-all-closed', async () => {
 app.on('activate', () => {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
+
   if (BrowserWindow.getAllWindows().length === 0) {
     createWindow()
   }


### PR DESCRIPTION
Fixes issues on Mac OS where user can close the window but then not reopen it from the task bar.