### PR TITLE
Pin node-app to node 16

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.13
+        node-version: 16.15.1
     - name: Install dependencies
       run: yarn
     - name: Build application
@@ -23,7 +23,7 @@ jobs:
   #   - uses: actions/checkout@v3
   #   - uses: actions/setup-node@v3
   #     with:
-  #       node-version: 18.13
+  #       node-version: 16.15.1
   #   - name: Install dependencies
   #     run: yarn
   #   - name: Build application
@@ -36,7 +36,7 @@ jobs:
   #   - uses: actions/checkout@v3
   #   - uses: actions/setup-node@v3
   #     with:
-  #       node-version: 18.13
+  #       node-version: 16.15.1
   #   - name: Install dependencies
   #     run: yarn
   #   - name: Build application

--- a/.github/workflows/publish-demo.yaml
+++ b/.github/workflows/publish-demo.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.13
+        node-version: 16.15.1
     - name: install dependencies
       run: yarn
     - name: publish
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.13
+        node-version: 16.15.1
     - name: install dependencies
       run: yarn
     - name: publish

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.13
+        node-version: 16.15.1
     - name: install dependencies
       run: yarn
     - name: publish
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.13
+        node-version: 16.15.1
     - name: install dependencies
       run: yarn
     - name: setup codesigning
@@ -122,7 +122,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.13
+        node-version: 16.15.1
     - name: install dependencies
       run: yarn
     - name: publish

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "web-vitals": "^2.1.4"
   },
   "engines": {
-    "node": ">=18 <19"
+    "node": "16.x"
   },
   "packageManager": "yarn@1.22.19",
   "browserslist": {


### PR DESCRIPTION
This is the version that gets bundled with electron, so specifying a highier version here doesn't make sense since that's not the version it'll run with in the end. This is waiting for https://github.com/iron-fish/ironfish/pull/4003 to be deployed to NPM, otherwise this branch won't build.