### PR TITLE
chore: Bump ui-kit to version 1.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@aws-sdk/client-s3": "3.127.0",
     "@ironfish/rust-nodejs": "1.2.0",
     "@ironfish/sdk": "1.4.0",
-    "@ironfish/ui-kit": "1.1.11",
+    "@ironfish/ui-kit": "1.1.12",
     "@types/nedb": "^1.8.12",
     "bech32": "^2.0.0",
     "date-fns": "^2.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,10 +3582,10 @@
     ws "8.12.1"
     yup "0.29.3"
 
-"@ironfish/ui-kit@1.1.11":
-  version "1.1.11"
-  resolved "https://registry.npmjs.org/@ironfish/ui-kit/-/ui-kit-1.1.11.tgz#ecbcc941bffa3baf9c9ba559e8b64538cc090b92"
-  integrity sha512-enf9DXZimhz+sbIfZPi7cjZMbhpFLq2bccpIc6V8vEssYYKO1OLE92f3Ni+cBvcnTQ+6v3y1A/fn+uWOAvnCEA==
+"@ironfish/ui-kit@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.npmjs.org/@ironfish/ui-kit/-/ui-kit-1.1.12.tgz#1c3fa95357847e893ccf9ec9493efc357d488bec"
+  integrity sha512-FUGq6loabYB0TMNH1JTzHu9ERLpLyQWpZOzXPciHRa64lrjM3IrV5DHhLOWT9sBIQGeFzirrvRohfm0H0KfYVw==
   dependencies:
     "@chakra-ui/icons" "2.0.17"
     "@chakra-ui/react" "2.5.1"


### PR DESCRIPTION
Bumps ui-kit version to fix icon in top right of screen.

<img width="1034" alt="Screenshot 2023-07-05 at 3 24 26 PM" src="https://github.com/iron-fish/node-app/assets/3639170/558d21fc-e28d-4c39-9c95-b75ba0a38676">
