### PR TITLE
Revert "chore: Bump @ironfish/sdk version"

### DIFF
--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -191,14 +191,7 @@ class AccountManager
     }
 
     if (decoded) {
-      const decodedData = JSONUtils.parse<
-        Omit<AccountImport, 'createdAt'> & {
-          createdAt: {
-            sequence: number
-            hash: string
-          }
-        }
-      >(decoded)
+      const decodedData = JSONUtils.parse<AccountImport>(decoded)
       const accountData: Omit<AccountValue, 'rescan'> = {
         id: uuid(),
         ...decodedData,

--- a/electron/ironfish/TransactionManager.ts
+++ b/electron/ironfish/TransactionManager.ts
@@ -2,6 +2,7 @@ import { Asset } from '@ironfish/rust-nodejs'
 import { DecryptedNoteValue } from '@ironfish/sdk/build/src/wallet/walletdb/decryptedNoteValue'
 import {
   Account,
+  IDatabaseTransaction,
   IronfishNode,
   RawTransaction,
   TransactionType,
@@ -375,12 +376,12 @@ class TransactionManager
     const account = this.node.wallet.getAccount(accountId)
     const head = await account.getHead()
 
-    const transaction = await this.node.wallet.send({
-      account: account,
-      outputs: [{ ...payment, assetId: Buffer.from(payment.assetId, 'hex') }],
-      fee: transactionFee,
-      expirationDelta: this.node.config.get('transactionExpirationDelta'),
-    })
+    const transaction = await this.node.wallet.send(
+      account,
+      [{ ...payment, assetId: Buffer.from(payment.assetId, 'hex') }],
+      transactionFee,
+      this.node.config.get('transactionExpirationDelta')
+    )
 
     const result = await this.resolveTransactionFields(
       account,

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.127.0",
     "@ironfish/rust-nodejs": "1.2.0",
-    "@ironfish/sdk": "1.5.0",
+    "@ironfish/sdk": "1.4.0",
     "@ironfish/ui-kit": "1.1.12",
     "@types/nedb": "^1.8.12",
     "bech32": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,18 +3417,6 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
-"@fast-csv/format@4.3.5":
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz#90d83d1b47b6aaf67be70d6118f84f3e12ee1ff3"
-  integrity sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==
-  dependencies:
-    "@types/node" "^14.0.1"
-    lodash.escaperegexp "^4.1.2"
-    lodash.isboolean "^3.0.3"
-    lodash.isequal "^4.5.0"
-    lodash.isfunction "^3.0.9"
-    lodash.isnil "^4.0.0"
-
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -3470,70 +3458,70 @@
   resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.2.0.tgz#7216d54ab0ca126a91b4e68a92bd12d004d0479d"
   integrity sha512-yFkn3VqEWZN3neFb/yMKhmiTFWklKwwWnwdTKQkpiqQoviv8npByfTd/Iq/amBCWD/DwDWd7EvGJ6RP0EHyq0w==
 
-"@ironfish/rust-nodejs-darwin-arm64@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.4.0.tgz#6f1b544016eac41b81c644e00f8162f6123c589f"
-  integrity sha512-rupvheRIsr5LQnBOrVs/Ef2Z4oQ4z1gnQgQyu4nxGKvAEkD9upOQY/WaOkmZrivP74GzsO63H7pIpAbMie1UoQ==
+"@ironfish/rust-nodejs-darwin-arm64@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.3.0.tgz#9a66e8e910af2f0d89c6b5423f45b7454b0a7549"
+  integrity sha512-1t5Mci9E/CeqkBpyyeorjExU0xpz0TyIBpIVsKN8X0eLqwZX7i16TV3T1wK+TuMGqGxkpBPT+Wf0yydeUV2A9Q==
 
 "@ironfish/rust-nodejs-darwin-x64@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.2.0.tgz#3e0a9e744379ecf251de36c9616c6ff114eedfc8"
   integrity sha512-N5oXXwWP7QoKQ4amaXGlkJ9ipBRKT3DgdrD1e9RsVt/Tw27nbaIgr7gyAmtsVjJawp6LqhapuT35+QzqQWcrdw==
 
-"@ironfish/rust-nodejs-darwin-x64@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.4.0.tgz#ba1d90c0a6fdaf93b96c4aad146b1cf20a5e46d6"
-  integrity sha512-4nZVU7yhisFzJCDzuEnUAu4q7AeuTJAEMGDIxhxZhmjqrwwO05QkBK2/kn8iPN0peZlegRxmj4chFwd7GH6ZHg==
+"@ironfish/rust-nodejs-darwin-x64@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.3.0.tgz#62df2cd3d742763de126714b715fe99094c32b87"
+  integrity sha512-eW6zalsQ4We82gjY5Y3tQeOsJfPMgNLoi77Y1l6Eww2sst5DQYKJG1++pAdZrGMlQ9OLI6L3bK0XDYE4LvWdxA==
 
 "@ironfish/rust-nodejs-linux-arm64-gnu@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.2.0.tgz#1659664faafc3f0a4e06370e408d740c14cc06e2"
   integrity sha512-R7cjfoXK+/ZVF0BQYNWhLJxdnVoq00ujZVGm02TQDbI4PiYJZoFD8auYqdQQPyWEC1+wV7bpRZK7hNZS+AVfpw==
 
-"@ironfish/rust-nodejs-linux-arm64-gnu@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.4.0.tgz#f1f0cc5029f5e28f46cdc9eec07f850735803fd2"
-  integrity sha512-jtNdBdicF2fSxax+FDoHJgnGLzTn69qGKyYsobVHU2aj9PT6KL1xUSghtyICZ7xahP6WuUW8UaEA5hVKVagG6A==
+"@ironfish/rust-nodejs-linux-arm64-gnu@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.3.0.tgz#1e4b6d2bc9033341c20950b9c462d974035a57db"
+  integrity sha512-DBa/R1WJMC4ihlx5enU1spk1vmSJmaBooMt4KewqUv+epoFwnjzH+DYxiZSayx/A5j25iDAV4QbH2o3l4hNZmQ==
 
 "@ironfish/rust-nodejs-linux-arm64-musl@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.2.0.tgz#6caa95778ba918ce0b09317d134dc7d6a88560b0"
   integrity sha512-n5NCbaR4JAWcJkTmneN6VAjjZ0B+p8LCzHfu2/JSkSNGURY4dPgz0ClXww53/RbpbmdywSjl+SezmBabqvlH0w==
 
-"@ironfish/rust-nodejs-linux-arm64-musl@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.4.0.tgz#1cc12664965c559e90b9c0131ee4f4de6ec9d392"
-  integrity sha512-VxL4BoXG18JZxJojd/oV3jr85RLBPyG3Qk7GASraWbML6TuQYjo2mOSoqpHecW0mk7lwzQh/sj87uxBd01oapQ==
+"@ironfish/rust-nodejs-linux-arm64-musl@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.3.0.tgz#eb56407b008a336ba407f6a7c915e8cc058630da"
+  integrity sha512-D3PsNYB+sdjsSDsWGs2RslTvzp/Ozu04jkubbL5K/riuMnTIAM7pQMJ28/uGlMgH5RHk2le/DSqRJ75D9b6xBQ==
 
 "@ironfish/rust-nodejs-linux-x64-gnu@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.2.0.tgz#2cd2945f30c5b919aaa88de09a2142db4093aede"
   integrity sha512-cbMLBdP+uZBeiumfuGTS0mARL97F0TCmiI+/oqzcPr4hOyyyzXKEnbwl68fzz8NX7Mp2de0E7hFVBpqSxfr99Q==
 
-"@ironfish/rust-nodejs-linux-x64-gnu@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.4.0.tgz#5a28e44a1cf30e984811784861fd6754f8209cc7"
-  integrity sha512-o/HgaTiRKUNsTOWpa3JYt0JBEx8vzPDXNvSi7rCOFrFzjY4vjws0Xg42VqOu5f9yEjipV5qN09vdKwPv1DV4kw==
+"@ironfish/rust-nodejs-linux-x64-gnu@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.3.0.tgz#73b95746f6c8cfe30b063da9200305d190dc3bd7"
+  integrity sha512-8Fk0oiWjjwyJ76mfLxPQD+xP6UxSw1UvQz8XKKXfyWiBYbAuM6BvSt1HQZRvOpjIk+uX7PbSodI2OC+YS5Qn+g==
 
 "@ironfish/rust-nodejs-linux-x64-musl@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.2.0.tgz#a65683c355a1036b1c770b47948c2e760dd2f208"
   integrity sha512-zr49BYNPKbiRxRMCd+rUAt8VTmjmc/rUK8qLlQ+49bH0V4i9vh4pJSSJXH+CSLh3O8f66P3H7Rbp+2AsHOLc0A==
 
-"@ironfish/rust-nodejs-linux-x64-musl@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.4.0.tgz#089f3df8755cd2d14e8867a757b43ea5423dbcdf"
-  integrity sha512-lBfE490xz0MfCf1QijPwteIJa+kQs+GeHjuIYukVYEJcrV7E2FrLomX/3aPilSJQGYiZlA9fZqlrBfp0cIzgug==
+"@ironfish/rust-nodejs-linux-x64-musl@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.3.0.tgz#df4dc35f19366d747d0cd432e2ecf55f6c90d085"
+  integrity sha512-MwARvzvBuAsjK59j6rabfx0lIW6S8cCj7vn1cVNhGqXhgBI00lCmybQXB92o1+wVnZm4P7bK9zQEXdCZ8Ad4Aw==
 
 "@ironfish/rust-nodejs-win32-x64-msvc@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.2.0.tgz#8e2f1f1016c955804d565b5ac68562efeb935d3a"
   integrity sha512-8PDedE9CHckI6qR/O2pxjbHg/MFXp5pUTrnjwb4a77CcDMq4+IKDVSPkMLxVfDkpR/cH/CGZT+02l7yQe274uA==
 
-"@ironfish/rust-nodejs-win32-x64-msvc@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.4.0.tgz#e62b65b6daa4e6783df2419c85164575d1098e2b"
-  integrity sha512-9/up8wkIKmb+IA0imJQtZD3/M3EjAekhuq3SPn8mGk9oGm74hgKibeTZFHRqes7gNPQ8vQ8xaS2HbIOFGhcrVw==
+"@ironfish/rust-nodejs-win32-x64-msvc@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.3.0.tgz#abb82781c5e37471db030e3b27c65c8948797760"
+  integrity sha512-miL9xmZq74aVa7PCbfhRXte10S/+8GqPeNfLMpUX7id15ssgGf3Z3KwKe3/LkGKwIaSVvn2R6jebRCTC1FN4Lw==
 
 "@ironfish/rust-nodejs@1.2.0":
   version "1.2.0"
@@ -3548,27 +3536,26 @@
     "@ironfish/rust-nodejs-linux-x64-musl" "1.2.0"
     "@ironfish/rust-nodejs-win32-x64-msvc" "1.2.0"
 
-"@ironfish/rust-nodejs@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-1.4.0.tgz#1b140f86402bdf7debfe2789776bca8f706860d9"
-  integrity sha512-ieZKU5oUAJB4nUj0unhudSfHtgWabpZEX0383h6q8nofrSrFh0rswrneintKHlPOEhK+IguZkhQBx3/LcQt5Tw==
+"@ironfish/rust-nodejs@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-1.3.0.tgz#2e65631b6d68c08633bfd2b6ea8c04ddc9e9134a"
+  integrity sha512-qNFAah8V+npoJBoNYmGkRs+8gri5JZFdM+NuhRG+v//pNpS5+XnegBMViUljz4Q3CTz0R9qgC2upzepYw0TdKQ==
   optionalDependencies:
-    "@ironfish/rust-nodejs-darwin-arm64" "1.4.0"
-    "@ironfish/rust-nodejs-darwin-x64" "1.4.0"
-    "@ironfish/rust-nodejs-linux-arm64-gnu" "1.4.0"
-    "@ironfish/rust-nodejs-linux-arm64-musl" "1.4.0"
-    "@ironfish/rust-nodejs-linux-x64-gnu" "1.4.0"
-    "@ironfish/rust-nodejs-linux-x64-musl" "1.4.0"
-    "@ironfish/rust-nodejs-win32-x64-msvc" "1.4.0"
+    "@ironfish/rust-nodejs-darwin-arm64" "1.3.0"
+    "@ironfish/rust-nodejs-darwin-x64" "1.3.0"
+    "@ironfish/rust-nodejs-linux-arm64-gnu" "1.3.0"
+    "@ironfish/rust-nodejs-linux-arm64-musl" "1.3.0"
+    "@ironfish/rust-nodejs-linux-x64-gnu" "1.3.0"
+    "@ironfish/rust-nodejs-linux-x64-musl" "1.3.0"
+    "@ironfish/rust-nodejs-win32-x64-msvc" "1.3.0"
 
-"@ironfish/sdk@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/@ironfish/sdk/-/sdk-1.5.0.tgz#05914e2565e5f444fef8bcc36eb5d2f61be02e91"
-  integrity sha512-PQDCZKrvcH7LfrOigRjfqjMlVzy7TOXuY8uPxpMuXz6dxvb60rZ5eE21kNhTxsqN+wN95p36hOWLySM16xoZsQ==
+"@ironfish/sdk@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/@ironfish/sdk/-/sdk-1.4.0.tgz#7748c2f29c4b64004d68d9a3815cf86cae86dd1b"
+  integrity sha512-Xpr7lL46uayEddFYdJT0gd57GG952OcHy/YFOPcsomep96JcAkSP10rrKcHRpnBEhnljODpZtJxymjKDNX+lLw==
   dependencies:
     "@ethersproject/bignumber" "5.7.0"
-    "@fast-csv/format" "4.3.5"
-    "@ironfish/rust-nodejs" "1.4.0"
+    "@ironfish/rust-nodejs" "1.3.0"
     "@napi-rs/blake-hash" "1.3.3"
     axios "0.21.4"
     bech32 "2.0.0"
@@ -3585,7 +3572,6 @@
     level-errors "2.0.1"
     leveldown "5.6.0"
     levelup "4.4.0"
-    libuv-monitor "0.0.3"
     lodash "4.17.21"
     node-datachannel "0.4.0"
     node-forge "1.3.1"
@@ -3948,26 +3934,6 @@
     rimraf "^3.0.2"
     semver "^7.3.5"
     tar "^6.1.11"
-
-"@mgeist/libuv-monitor-darwin-arm64@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/@mgeist/libuv-monitor-darwin-arm64/-/libuv-monitor-darwin-arm64-0.0.3.tgz#3fa9ec01a9a7e437b5bf894e9f03b59fe26411b6"
-  integrity sha512-jaHid8UEDNyASzBeY5qrbC5SJfFYr9z9wNuGhJbkVXQT//JN9fxe2g/YHJjEGR/u5P4nDy6EUeqXfnIdSiNuTQ==
-
-"@mgeist/libuv-monitor-darwin-x64@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/@mgeist/libuv-monitor-darwin-x64/-/libuv-monitor-darwin-x64-0.0.3.tgz#7887419f3e8d409f0426772ea14d4f2399339aeb"
-  integrity sha512-k+CAZ3xUXu3JX0P25N6yhcvfl6h5XQv2D/RDyCJ0I+OSoL5jICvDAcl4J/AtUPlWagWdmRoP+UEaFXOytf0/ww==
-
-"@mgeist/libuv-monitor-linux-arm64@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/@mgeist/libuv-monitor-linux-arm64/-/libuv-monitor-linux-arm64-0.0.3.tgz#ad7da0b88010f405864a911939910af3ee59f0e6"
-  integrity sha512-l8uK50x8c72/GpRzdE3LwlDCtb87VozWBuvo64uIzBtR53e3NLs45FJIIHiqQSEBY6fM0FI+jTRRV69pqN5j4A==
-
-"@mgeist/libuv-monitor-linux-x64@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/@mgeist/libuv-monitor-linux-x64/-/libuv-monitor-linux-x64-0.0.3.tgz#0865de01775caca40ac8909cc60f7658c16e4e99"
-  integrity sha512-BMhlft+AhTZGsaEEFXIbYGHrA/aZv4FQbzWqbouHf5CpM1lXSW8/6+IA5RyIOz4yddRQLx5S/LVjdw21+k4Ptw==
 
 "@napi-rs/blake-hash-android-arm64@1.3.3":
   version "1.3.3"
@@ -4893,11 +4859,6 @@
   version "18.16.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.3.tgz#6bda7819aae6ea0b386ebc5b24bdf602f1b42b01"
   integrity sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==
-
-"@types/node@^14.0.1":
-  version "14.18.53"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz#42855629b8773535ab868238718745bf56c56219"
-  integrity sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==
 
 "@types/node@^16.11.26":
   version "16.18.28"
@@ -11582,16 +11543,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libuv-monitor@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/libuv-monitor/-/libuv-monitor-0.0.3.tgz#72d6076d88b4906a6ef83ef43ee2ea026e092b27"
-  integrity sha512-IN/SjTpCr+E3v2+WAYNftcyBSLYl3sksrKPup9WlPLapQisPRdv6q2acGNmoIdv7GitED/Nzpuip0orH3lLhEA==
-  optionalDependencies:
-    "@mgeist/libuv-monitor-darwin-arm64" "0.0.3"
-    "@mgeist/libuv-monitor-darwin-x64" "0.0.3"
-    "@mgeist/libuv-monitor-linux-arm64" "0.0.3"
-    "@mgeist/libuv-monitor-linux-x64" "0.0.3"
-
 lie@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
@@ -11737,11 +11688,6 @@ lodash.escape@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
   integrity sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==
 
-lodash.escaperegexp@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
-  integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -11752,25 +11698,10 @@ lodash.get@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
-lodash.isboolean@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
-  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
-
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
-
-lodash.isfunction@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
-
-lodash.isnil@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
-  integrity sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==
 
 lodash.memoize@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
The SDK update isn't building on certain OSes. Let's revert this to unblock releasing updates, especially since one of the changes in v1.0.1 fixes auto-updating.
