### PR TITLE
Update Node App SDK to v1.9.0

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -1,9 +1,6 @@
 name: Publish Production
 permissions: write-all
-on:
-  push:
-    tags:
-      - 'v*'
+on: push
 
 jobs:
 

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -1,6 +1,9 @@
 name: Publish Production
 permissions: write-all
-on: push
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
 

--- a/electron/ironfish/AbstractManager.ts
+++ b/electron/ironfish/AbstractManager.ts
@@ -1,9 +1,9 @@
-import { IronfishNode } from '@ironfish/sdk'
+import { FullNode } from '@ironfish/sdk'
 
 abstract class AbstractManager {
-  protected node: IronfishNode
+  protected node: FullNode
 
-  constructor(node: IronfishNode) {
+  constructor(node: FullNode) {
     this.node = node
   }
 

--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -2,7 +2,7 @@ import {
   AccountValue,
   ACCOUNT_SCHEMA_VERSION,
   CurrencyUtils,
-  IronfishNode,
+  FullNode,
   Bech32m,
   JSONUtils,
   isValidPublicAddress,
@@ -36,7 +36,7 @@ class AccountManager
 {
   private assetManager: AssetManager
 
-  constructor(node: IronfishNode, assetManager: AssetManager) {
+  constructor(node: FullNode, assetManager: AssetManager) {
     super(node)
     this.assetManager = assetManager
   }
@@ -191,7 +191,14 @@ class AccountManager
     }
 
     if (decoded) {
-      const decodedData = JSONUtils.parse<AccountImport>(decoded)
+      const decodedData = JSONUtils.parse<
+        Omit<AccountImport, 'createdAt'> & {
+          createdAt: {
+            sequence: number
+            hash: string
+          }
+        }
+      >(decoded)
       const accountData: Omit<AccountValue, 'rescan'> = {
         id: uuid(),
         ...decodedData,

--- a/electron/ironfish/AssetManager.ts
+++ b/electron/ironfish/AssetManager.ts
@@ -19,7 +19,6 @@ class AssetManager extends AbstractManager implements IIronfishAssetManager {
 
   async list(search?: string, offset = 0, max = 100): Promise<Asset[]> {
     const assets: Asset[] = []
-
     const bufferedAssets = [this.DEFAULT_ASSET].concat(
       await this.node.chain.blockchainDb.assets.getAllValues()
     )

--- a/electron/ironfish/AssetManager.ts
+++ b/electron/ironfish/AssetManager.ts
@@ -12,14 +12,16 @@ class AssetManager extends AbstractManager implements IIronfishAssetManager {
     metadata: Buffer.from('Native asset of Iron Fish blockchain', 'utf8'),
     name: Buffer.from('$IRON', 'utf8'),
     owner: Buffer.from('Iron Fish', 'utf8'),
+    creator: Buffer.from('Iron Fish', 'utf8'),
     supply: BigInt(0),
     nonce: 0,
   }
 
   async list(search?: string, offset = 0, max = 100): Promise<Asset[]> {
     const assets: Asset[] = []
+
     const bufferedAssets = [this.DEFAULT_ASSET].concat(
-      await this.node.chain.assets.getAllValues()
+      await this.node.chain.blockchainDb.assets.getAllValues()
     )
     bufferedAssets.forEach((bufferedAsset: AssetValue) => {
       const asset = this.resolveAsset(bufferedAsset)

--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -1,7 +1,7 @@
 import { BoxKeyPair } from '@ironfish/rust-nodejs'
 import { v4 as uuid } from 'uuid'
 import {
-  IronfishNode,
+  FullNode,
   IronfishSdk,
   NodeUtils,
   PrivateIdentity,
@@ -38,7 +38,7 @@ import { app, shell } from 'electron'
 export class IronFishManager implements IIronfishManager {
   protected initStatus: IronFishInitStatus = IronFishInitStatus.NOT_STARTED
   protected sdk: IronfishSdk
-  protected node: IronfishNode
+  protected node: FullNode
   accounts: AccountManager
   assets: AssetManager
   nodeSettings: NodeSettingsManager

--- a/electron/ironfish/NodeSettingsManager.ts
+++ b/electron/ironfish/NodeSettingsManager.ts
@@ -1,5 +1,5 @@
 import {
-  IronfishNode,
+  FullNode,
   setUnknownConfigValue,
   Config,
   ConfigOptions,
@@ -13,7 +13,7 @@ class NodeSettingsManager
 {
   private config: Config
 
-  constructor(node: IronfishNode) {
+  constructor(node: FullNode) {
     super(node)
     this.config = node.config
   }

--- a/electron/ironfish/SnapshotManager.ts
+++ b/electron/ironfish/SnapshotManager.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 import { deleteAsync } from 'del'
 import path from 'path'
 import tar from 'tar'
-import { IronfishNode, Meter, VERSION_DATABASE_CHAIN } from '@ironfish/sdk'
+import { FullNode, Meter, VERSION_DATABASE_CHAIN } from '@ironfish/sdk'
 import {
   IIronfishSnapshotManager,
   SnapshotProgressStatus,
@@ -27,7 +27,7 @@ class SnapshotManager
   private filePath: string
   private pathToSave: string
 
-  constructor(node: IronfishNode) {
+  constructor(node: FullNode) {
     super(node)
     this.onStatusChange({
       status: SnapshotProgressStatus.NOT_STARTED,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-app",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "Iron Fish Node App",
   "main": ".webpack/main",
   "repository": "https://github.com/iron-fish/node-app",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-app",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Iron Fish Node App",
   "main": ".webpack/main",
   "repository": "https://github.com/iron-fish/node-app",
@@ -97,8 +97,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.127.0",
-    "@ironfish/rust-nodejs": "1.2.0",
-    "@ironfish/sdk": "1.4.0",
+    "@ironfish/rust-nodejs": "1.8.0",
+    "@ironfish/sdk": "1.9.0",
     "@ironfish/ui-kit": "1.1.12",
     "@types/nedb": "^1.8.12",
     "bech32": "^2.0.0",

--- a/src/data/DemoDataManager.ts
+++ b/src/data/DemoDataManager.ts
@@ -15,7 +15,6 @@ import { IIronfishTransactionManager } from 'Types/IronfishManager/IIronfishTran
 import { IIronfishSnapshotManager } from 'Types/IronfishManager/IIronfishSnapshotManager'
 import { INodeSettingsManager } from 'Types/IronfishManager/INodeSettingsManager'
 import EventType from 'Types/EventType'
-import { app } from 'electron'
 
 class DemoDataManager implements IIronfishManager {
   private internalConfig = { isFirstRun: true }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,6 +3417,18 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
+"@fast-csv/format@4.3.5":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@fast-csv/format/-/format-4.3.5.tgz#90d83d1b47b6aaf67be70d6118f84f3e12ee1ff3"
+  integrity sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==
+  dependencies:
+    "@types/node" "^14.0.1"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isboolean "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isnil "^4.0.0"
+
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -3453,109 +3465,62 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@ironfish/rust-nodejs-darwin-arm64@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.2.0.tgz#7216d54ab0ca126a91b4e68a92bd12d004d0479d"
-  integrity sha512-yFkn3VqEWZN3neFb/yMKhmiTFWklKwwWnwdTKQkpiqQoviv8npByfTd/Iq/amBCWD/DwDWd7EvGJ6RP0EHyq0w==
+"@ironfish/rust-nodejs-darwin-arm64@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.8.0.tgz#28e150f7ad51dd6b66fcf995c8476eff62828b0c"
+  integrity sha512-L4hgcIZ25azTQ5WPC4T8rDMh3wu8FZtpPiCD7WRIWbAemE9iKeivQcuBkaFcGd5Bz2B6D4gs01WgCCw+nq3r5w==
 
-"@ironfish/rust-nodejs-darwin-arm64@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.3.0.tgz#9a66e8e910af2f0d89c6b5423f45b7454b0a7549"
-  integrity sha512-1t5Mci9E/CeqkBpyyeorjExU0xpz0TyIBpIVsKN8X0eLqwZX7i16TV3T1wK+TuMGqGxkpBPT+Wf0yydeUV2A9Q==
+"@ironfish/rust-nodejs-darwin-x64@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.8.0.tgz#7beffda4874fa3d07a45f674f55f3c1e421e8bef"
+  integrity sha512-hqBznqDeSsbZmZZXXvZLq95K/r9xDXVNrlNPqvDKEzcn9kBfC54TXHYiseClV5aJA05o2G7gOWZKTiC10G9YhQ==
 
-"@ironfish/rust-nodejs-darwin-x64@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.2.0.tgz#3e0a9e744379ecf251de36c9616c6ff114eedfc8"
-  integrity sha512-N5oXXwWP7QoKQ4amaXGlkJ9ipBRKT3DgdrD1e9RsVt/Tw27nbaIgr7gyAmtsVjJawp6LqhapuT35+QzqQWcrdw==
+"@ironfish/rust-nodejs-linux-arm64-gnu@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.8.0.tgz#cd414b6a9b9457da824b2a766d01373b59465a14"
+  integrity sha512-Y9EAVkXhVwQWhs7WLO0qlIfJtURWNOfvPrzMfXFl5azgQM7qwsTqDIGb1vabLVxhppx+WK70NheTWwYYZ2or9g==
 
-"@ironfish/rust-nodejs-darwin-x64@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.3.0.tgz#62df2cd3d742763de126714b715fe99094c32b87"
-  integrity sha512-eW6zalsQ4We82gjY5Y3tQeOsJfPMgNLoi77Y1l6Eww2sst5DQYKJG1++pAdZrGMlQ9OLI6L3bK0XDYE4LvWdxA==
+"@ironfish/rust-nodejs-linux-arm64-musl@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.8.0.tgz#ed1454ef6ff51543518011474dedfd0e439a59fb"
+  integrity sha512-AgrjQA3Rp0ME4CmK8JEqybaiFX+fuyYcIqfE+ZJLOpAtk1J1N0TbfW3x1uJ45UsPNaDvjpi+qyeeWXPhp+yVUA==
 
-"@ironfish/rust-nodejs-linux-arm64-gnu@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.2.0.tgz#1659664faafc3f0a4e06370e408d740c14cc06e2"
-  integrity sha512-R7cjfoXK+/ZVF0BQYNWhLJxdnVoq00ujZVGm02TQDbI4PiYJZoFD8auYqdQQPyWEC1+wV7bpRZK7hNZS+AVfpw==
+"@ironfish/rust-nodejs-linux-x64-gnu@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.8.0.tgz#3329795f73ab29e580106279f4bd84981770f444"
+  integrity sha512-0MPRhAJ1BmyV/6KcY8ycGTN7AthPN2ieUFp3ggtg/NBcAPZ+3DGMLtgBsKmqvlbTdOW9HVMQBJn3orEo8bPSRQ==
 
-"@ironfish/rust-nodejs-linux-arm64-gnu@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.3.0.tgz#1e4b6d2bc9033341c20950b9c462d974035a57db"
-  integrity sha512-DBa/R1WJMC4ihlx5enU1spk1vmSJmaBooMt4KewqUv+epoFwnjzH+DYxiZSayx/A5j25iDAV4QbH2o3l4hNZmQ==
+"@ironfish/rust-nodejs-linux-x64-musl@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.8.0.tgz#8707c5e128604598627c7e6e9e9ad488ee28b390"
+  integrity sha512-f6lTNU0MCC3ORkM6aGcE4jmjiFH0UEPLZpKv55dWkXlIE8iFDkbzIPzTWpY8iFgJeaG4m6zRvk99oajYGjUQtg==
 
-"@ironfish/rust-nodejs-linux-arm64-musl@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.2.0.tgz#6caa95778ba918ce0b09317d134dc7d6a88560b0"
-  integrity sha512-n5NCbaR4JAWcJkTmneN6VAjjZ0B+p8LCzHfu2/JSkSNGURY4dPgz0ClXww53/RbpbmdywSjl+SezmBabqvlH0w==
+"@ironfish/rust-nodejs-win32-x64-msvc@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.8.0.tgz#956e96c3bca88de104fe4d5f315f5b4eaa3d6545"
+  integrity sha512-zyMf4iJr+6Z917PQxLsrA9FOpVrnpaVCZLRVgU6ag4BfU+9vUQElx9f4OSXuzV3M7EHKe73A3ql2UHaqzZCQLQ==
 
-"@ironfish/rust-nodejs-linux-arm64-musl@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.3.0.tgz#eb56407b008a336ba407f6a7c915e8cc058630da"
-  integrity sha512-D3PsNYB+sdjsSDsWGs2RslTvzp/Ozu04jkubbL5K/riuMnTIAM7pQMJ28/uGlMgH5RHk2le/DSqRJ75D9b6xBQ==
-
-"@ironfish/rust-nodejs-linux-x64-gnu@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.2.0.tgz#2cd2945f30c5b919aaa88de09a2142db4093aede"
-  integrity sha512-cbMLBdP+uZBeiumfuGTS0mARL97F0TCmiI+/oqzcPr4hOyyyzXKEnbwl68fzz8NX7Mp2de0E7hFVBpqSxfr99Q==
-
-"@ironfish/rust-nodejs-linux-x64-gnu@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.3.0.tgz#73b95746f6c8cfe30b063da9200305d190dc3bd7"
-  integrity sha512-8Fk0oiWjjwyJ76mfLxPQD+xP6UxSw1UvQz8XKKXfyWiBYbAuM6BvSt1HQZRvOpjIk+uX7PbSodI2OC+YS5Qn+g==
-
-"@ironfish/rust-nodejs-linux-x64-musl@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.2.0.tgz#a65683c355a1036b1c770b47948c2e760dd2f208"
-  integrity sha512-zr49BYNPKbiRxRMCd+rUAt8VTmjmc/rUK8qLlQ+49bH0V4i9vh4pJSSJXH+CSLh3O8f66P3H7Rbp+2AsHOLc0A==
-
-"@ironfish/rust-nodejs-linux-x64-musl@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.3.0.tgz#df4dc35f19366d747d0cd432e2ecf55f6c90d085"
-  integrity sha512-MwARvzvBuAsjK59j6rabfx0lIW6S8cCj7vn1cVNhGqXhgBI00lCmybQXB92o1+wVnZm4P7bK9zQEXdCZ8Ad4Aw==
-
-"@ironfish/rust-nodejs-win32-x64-msvc@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.2.0.tgz#8e2f1f1016c955804d565b5ac68562efeb935d3a"
-  integrity sha512-8PDedE9CHckI6qR/O2pxjbHg/MFXp5pUTrnjwb4a77CcDMq4+IKDVSPkMLxVfDkpR/cH/CGZT+02l7yQe274uA==
-
-"@ironfish/rust-nodejs-win32-x64-msvc@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.3.0.tgz#abb82781c5e37471db030e3b27c65c8948797760"
-  integrity sha512-miL9xmZq74aVa7PCbfhRXte10S/+8GqPeNfLMpUX7id15ssgGf3Z3KwKe3/LkGKwIaSVvn2R6jebRCTC1FN4Lw==
-
-"@ironfish/rust-nodejs@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs/-/rust-nodejs-1.2.0.tgz#57530d62eb00ddf56ef6f3e55b6d0466e8cc1f0f"
-  integrity sha512-Dhs++ZGTHDEt8KHuL1uozOipZVeyVcM3ywUTQExcw5RXFXKwiJ2VQdA/qtvcyYwXgK5jvr4xBEbZMIakPnVM5Q==
+"@ironfish/rust-nodejs@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/rust-nodejs/-/rust-nodejs-1.8.0.tgz#d03d4e92dc1b4d14e8fe49fdeacf78eac5d16b24"
+  integrity sha512-HkCZiuzPpJP4MnWIXfdIjK0DCepuDngoPLECVR9LjFHNMRtT4Z+xrGJeah+j8ME0bMBM/q0675GsgjiiPnz5FA==
   optionalDependencies:
-    "@ironfish/rust-nodejs-darwin-arm64" "1.2.0"
-    "@ironfish/rust-nodejs-darwin-x64" "1.2.0"
-    "@ironfish/rust-nodejs-linux-arm64-gnu" "1.2.0"
-    "@ironfish/rust-nodejs-linux-arm64-musl" "1.2.0"
-    "@ironfish/rust-nodejs-linux-x64-gnu" "1.2.0"
-    "@ironfish/rust-nodejs-linux-x64-musl" "1.2.0"
-    "@ironfish/rust-nodejs-win32-x64-msvc" "1.2.0"
+    "@ironfish/rust-nodejs-darwin-arm64" "1.8.0"
+    "@ironfish/rust-nodejs-darwin-x64" "1.8.0"
+    "@ironfish/rust-nodejs-linux-arm64-gnu" "1.8.0"
+    "@ironfish/rust-nodejs-linux-arm64-musl" "1.8.0"
+    "@ironfish/rust-nodejs-linux-x64-gnu" "1.8.0"
+    "@ironfish/rust-nodejs-linux-x64-musl" "1.8.0"
+    "@ironfish/rust-nodejs-win32-x64-msvc" "1.8.0"
 
-"@ironfish/rust-nodejs@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-1.3.0.tgz#2e65631b6d68c08633bfd2b6ea8c04ddc9e9134a"
-  integrity sha512-qNFAah8V+npoJBoNYmGkRs+8gri5JZFdM+NuhRG+v//pNpS5+XnegBMViUljz4Q3CTz0R9qgC2upzepYw0TdKQ==
-  optionalDependencies:
-    "@ironfish/rust-nodejs-darwin-arm64" "1.3.0"
-    "@ironfish/rust-nodejs-darwin-x64" "1.3.0"
-    "@ironfish/rust-nodejs-linux-arm64-gnu" "1.3.0"
-    "@ironfish/rust-nodejs-linux-arm64-musl" "1.3.0"
-    "@ironfish/rust-nodejs-linux-x64-gnu" "1.3.0"
-    "@ironfish/rust-nodejs-linux-x64-musl" "1.3.0"
-    "@ironfish/rust-nodejs-win32-x64-msvc" "1.3.0"
-
-"@ironfish/sdk@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@ironfish/sdk/-/sdk-1.4.0.tgz#7748c2f29c4b64004d68d9a3815cf86cae86dd1b"
-  integrity sha512-Xpr7lL46uayEddFYdJT0gd57GG952OcHy/YFOPcsomep96JcAkSP10rrKcHRpnBEhnljODpZtJxymjKDNX+lLw==
+"@ironfish/sdk@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@ironfish/sdk/-/sdk-1.9.0.tgz#a6a0a6ecbff406be7b0e3053d0707280d88b26ee"
+  integrity sha512-Os29rWsehLRO359zPu/5KT6n2uL5pvp1n2ri/sZgGMXklh9j4zqPWcoV1OKDDUYiPLMsQ+b9fkTdiGRXQa6RAw==
   dependencies:
     "@ethersproject/bignumber" "5.7.0"
-    "@ironfish/rust-nodejs" "1.3.0"
+    "@fast-csv/format" "4.3.5"
+    "@ironfish/rust-nodejs" "1.8.0"
     "@napi-rs/blake-hash" "1.3.3"
     axios "0.21.4"
     bech32 "2.0.0"
@@ -4859,6 +4824,11 @@
   version "18.16.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.3.tgz#6bda7819aae6ea0b386ebc5b24bdf602f1b42b01"
   integrity sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==
+
+"@types/node@^14.0.1":
+  version "14.18.56"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.56.tgz#09e092d684cd8cfbdb3c5e5802672712242f2600"
+  integrity sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==
 
 "@types/node@^16.11.26":
   version "16.18.28"
@@ -11688,6 +11658,11 @@ lodash.escape@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
   integrity sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==
 
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -11698,10 +11673,25 @@ lodash.get@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
+lodash.isfunction@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
+lodash.isnil@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
+  integrity sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==
 
 lodash.memoize@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
Updates the Iron Fish SDK in the Node App to v1.9.0. This also syncs the rust-nodejs package version with that of the SDK, which reduces the bundle size by around 50MB.

### Manual Testing

* [x] App starts up on macOS
* [x] App automatically applies migrations on startup 