### PR TITLE
Update update server URL to fix Windows auto-updating

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -1,9 +1,6 @@
 name: Publish Production
 permissions: write-all
-on:
-  push:
-    tags:
-      - 'v*'
+on: push
 
 jobs:
 

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -121,7 +121,7 @@ jobs:
       with:
         node-version: 18.13
     - name: install dependencies
-      run: yarn
+      run: yarn install --network-timeout 600000
     - name: publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -1,6 +1,9 @@
 name: Publish Production
 permissions: write-all
-on: push
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
 

--- a/electron/common/UpdateManager.ts
+++ b/electron/common/UpdateManager.ts
@@ -9,7 +9,7 @@ import axios from 'axios'
 import log from 'electron-log'
 
 class UpdateManager implements IUpdateManager {
-  private serverUrl = 'https://node-app-update-server-ironfish.vercel.app/'
+  private serverUrl = 'https://node-app-update-server-ironfish.vercel.app'
   private url: string
   private status: UpdateStatus = {
     ignoreUpdates: false,
@@ -25,7 +25,10 @@ class UpdateManager implements IUpdateManager {
       platform += '_arm64'
     }
 
-    this.url = `${this.serverUrl}/update/${platform}/${app.getVersion()}`
+    this.url = new URL(
+      `/update/${platform}/${app.getVersion()}`,
+      this.serverUrl
+    ).href
 
     if (app.isPackaged) {
       autoUpdater.setFeedURL({ url: this.url })

--- a/electron/common/UpdateManager.ts
+++ b/electron/common/UpdateManager.ts
@@ -9,9 +9,7 @@ import axios from 'axios'
 import log from 'electron-log'
 
 class UpdateManager implements IUpdateManager {
-  private serverUrl =
-    process.env.UPDATE_SERVER ||
-    'https://node-app-update-server-ironfish.vercel.app'
+  private serverUrl = 'https://node-app-update-server-ironfish.vercel.app/'
   private url: string
   private status: UpdateStatus = {
     ignoreUpdates: false,

--- a/electron/common/UpdateManager.ts
+++ b/electron/common/UpdateManager.ts
@@ -31,7 +31,17 @@ class UpdateManager implements IUpdateManager {
     ).href
 
     if (app.isPackaged) {
-      autoUpdater.setFeedURL({ url: this.url })
+      autoUpdater.on('checking-for-update', () => {
+        log.log('Checking for updates')
+      })
+
+      autoUpdater.on('update-available', () => {
+        log.log('Update is available')
+      })
+
+      autoUpdater.on('update-not-available', () => {
+        log.log('No update is available')
+      })
 
       autoUpdater.on(
         'update-downloaded',
@@ -56,6 +66,8 @@ class UpdateManager implements IUpdateManager {
           error: error.message,
         }
       })
+
+      autoUpdater.setFeedURL({ url: this.url })
     }
 
     return Promise.resolve()

--- a/electron/common/UpdateManager.ts
+++ b/electron/common/UpdateManager.ts
@@ -9,7 +9,9 @@ import axios from 'axios'
 import log from 'electron-log'
 
 class UpdateManager implements IUpdateManager {
-  private serverUrl = 'https://node-app-update-server-ironfish.vercel.app'
+  private serverUrl =
+    process.env.UPDATE_SERVER ||
+    'https://node-app-update-server-ironfish.vercel.app'
   private url: string
   private status: UpdateStatus = {
     ignoreUpdates: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-app",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "Iron Fish Node App",
   "main": ".webpack/main",
   "repository": "https://github.com/iron-fish/node-app",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-app",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Iron Fish Node App",
   "main": ".webpack/main",
   "repository": "https://github.com/iron-fish/node-app",

--- a/scripts/demo-update-server.js
+++ b/scripts/demo-update-server.js
@@ -1,0 +1,28 @@
+/* eslint-disable */
+/**
+ * Mock implementation of an update server for testing Windows app auto-updating.
+ * The updater should attempt to download the update, but it will currently error with "incorrect checksum".
+ * 
+ * You'll need to change UpdateManager's serverUrl to point to this server, then produce a Windows build of the app 
+ * with the change. (The auto-updating won't run unless wrapped with Squirrel, so no dev mode.)
+ * 
+ * Run with `node demo-update-server.js`
+ */
+const http = require('http')
+
+const server = http.createServer((req, res) => {
+  console.log('new request:', req.url)
+  res.statusCode = 200
+  if (req.url.includes('notes')) {
+    res.setHeader('Content-Type', 'application/json')
+    res.end(
+      `{"data":[{"version":"v1.0.3","name":"Version 1.0.3","date":"2023-09-03T15:32:52Z","notes":"","prevVersion":"v1.0.2","nextVersion":null}],"metadata":{"month_range":[{"month":"September 2023","version":"v1.0.3"}],"has_next":true,"has_prev":false}}`
+    )
+  } else {
+    res.end(
+      `169EDD50098860BF44F00CDE8121418EA2083475 node_app-1.0.3-full.nupkg 281682835`
+    )
+  }
+})
+
+server.listen(3222, '127.0.0.1')


### PR DESCRIPTION
The update server URL had two slashes, which caused the Windows auto-update code to error. This uses the URL constructor to parse the URL, which is a bit more resistant to extra slashes. Also added a few more logs to the auto-updater to track when it checks for updates and whether an update is available or no, and added a mock update server to the scripts folder for use when testing auto-updating in the future.

Also added a network timeout to yarn install on the Windows build, since it was failing a decent amount.