### PR TITLE
Wrap IPC response data in object

### DIFF
--- a/electron/common/initHandlers.ts
+++ b/electron/common/initHandlers.ts
@@ -24,7 +24,7 @@ async function shutdownNode() {
   return await ironfishManager.stop()
 }
 
-function handleError(error: unknown): {
+export function handleError(error: unknown): {
   error: true
   message: string
   name?: string

--- a/electron/common/initHandlers.ts
+++ b/electron/common/initHandlers.ts
@@ -55,7 +55,7 @@ ipcMain.handle(
   'ironfish-manager',
   async (e, action: IronfishManagerAction, ...args): Promise<any> => {
     try {
-      return await ironfishManager[action](...args)
+      return { error: false, data: await ironfishManager[action](...args) }
     } catch (error) {
       return handleError(error)
     }
@@ -65,9 +65,11 @@ ipcMain.handle(
 ipcMain.handle(
   'ironfish-manager-assets',
   async (e, action: IronfishAssetManagerActions, ...args): Promise<any> => {
-    let result
     try {
-      return await ironfishManager.assets[action](...args)
+      return {
+        error: false,
+        data: await ironfishManager.assets[action](...args),
+      }
     } catch (error) {
       return handleError(error)
     }
@@ -78,7 +80,10 @@ ipcMain.handle(
   'ironfish-manager-accounts',
   async (e, action: IronfishAccountManagerAction, ...args): Promise<any> => {
     try {
-      return await ironfishManager.accounts[action](...args)
+      return {
+        error: false,
+        data: await ironfishManager.accounts[action](...args),
+      }
     } catch (error) {
       return handleError(error)
     }
@@ -93,7 +98,10 @@ ipcMain.handle(
     ...args
   ): Promise<any> => {
     try {
-      return await ironfishManager.transactions[action](...args)
+      return {
+        error: false,
+        data: await ironfishManager.transactions[action](...args),
+      }
     } catch (error) {
       return handleError(error)
     }
@@ -104,12 +112,13 @@ ipcMain.handle(
   'ironfish-manager-snapshot',
   async (e, action: IronfishSnaphotManagerAction, ...args): Promise<any> => {
     try {
-      return await ironfishManager.snapshot[action](...args)
+      return {
+        error: false,
+        data: await ironfishManager.snapshot[action](...args),
+      }
     } catch (error) {
       return handleError(error)
     }
-
-    return result
   }
 )
 
@@ -117,7 +126,7 @@ ipcMain.handle(
   'update-manager',
   async (e, action: UpdateManagerAction, ...args) => {
     try {
-      return await UpdateManager[action](...args)
+      return { error: false, data: await UpdateManager[action](...args) }
     } catch (error) {
       return handleError(error)
     }
@@ -127,9 +136,8 @@ ipcMain.handle(
 ipcMain.handle(
   'error-manager',
   async (e, action: ErrorManagerActions, ...args) => {
-    let result
     try {
-      return await errorManager[action](...args)
+      return { error: false, data: await errorManager[action](...args) }
     } catch (error) {
       return handleError(error)
     }

--- a/electron/common/initStorage.ts
+++ b/electron/common/initStorage.ts
@@ -2,6 +2,7 @@ import { IpcMain } from 'electron/main'
 import AbstractStorage from '../storage/AbstractStorage'
 import AccountSettingsStorage from '../storage/AccountSettingsStorage'
 import AddressBookStorage from '../storage/AddressBookStorage'
+import { handleError } from './initHandlers'
 
 import Entity from 'Types/Entity'
 
@@ -12,18 +13,53 @@ const storages: Record<string, AbstractStorage<Entity>> = {
 
 function initStorageCallbacks(ipcMain: IpcMain) {
   Object.entries(storages).forEach(([storageName, storage]) => {
-    ipcMain.handle(storageName + '-list', (e, searchTerm, sort) =>
-      storage.list(searchTerm, sort)
-    )
-    ipcMain.handle(storageName + '-get', (e, identity) => storage.get(identity))
-    ipcMain.handle(storageName + '-add', (e, entity) => storage.add(entity))
-    ipcMain.handle(storageName + '-update', (e, identity, entity) =>
-      storage.update(identity, entity)
-    )
-    ipcMain.handle(storageName + '-delete', (e, identity) =>
-      storage.delete(identity)
-    )
-    ipcMain.handle(storageName + '-find', (e, fields) => storage.find(fields))
+    ipcMain.handle(storageName + '-list', (e, searchTerm, sort) => {
+      try {
+        return { error: false, data: storage.list(searchTerm, sort) }
+      } catch (error) {
+        return handleError(error)
+      }
+    })
+
+    ipcMain.handle(storageName + '-get', (e, identity) => {
+      try {
+        return { error: false, data: storage.get(identity) }
+      } catch (error) {
+        return handleError(error)
+      }
+    })
+
+    ipcMain.handle(storageName + '-add', (e, entity) => {
+      try {
+        return { error: false, data: storage.add(entity) }
+      } catch (error) {
+        return handleError(error)
+      }
+    })
+
+    ipcMain.handle(storageName + '-update', (e, identity, entity) => {
+      try {
+        return { error: false, data: storage.update(identity, entity) }
+      } catch (error) {
+        return handleError(error)
+      }
+    })
+
+    ipcMain.handle(storageName + '-delete', (e, identity) => {
+      try {
+        return { error: false, data: storage.delete(identity) }
+      } catch (error) {
+        return handleError(error)
+      }
+    })
+
+    ipcMain.handle(storageName + '-find', (e, fields) => {
+      try {
+        return { error: false, data: storage.find(fields) }
+      } catch (error) {
+        return handleError(error)
+      }
+    })
   })
 }
 

--- a/electron/contextBridge/util.ts
+++ b/electron/contextBridge/util.ts
@@ -6,7 +6,7 @@ export async function invoke(channel: string, ...args: any[]): Promise<any> {
     const response = await ipcRenderer.invoke(channel, ...args)
 
     if (typeof response?.error !== 'boolean') {
-      log.warn(`Expected 'error' field on IPC response.`)
+      log.warn(`Expected 'error' field on IPC response.`, channel, ...args)
     }
 
     if (response?.error) {

--- a/electron/contextBridge/util.ts
+++ b/electron/contextBridge/util.ts
@@ -1,13 +1,19 @@
 import { ipcRenderer } from 'electron'
+import log from 'electron-log'
 
 export async function invoke(channel: string, ...args: any[]): Promise<any> {
   try {
     const response = await ipcRenderer.invoke(channel, ...args)
+
+    if (typeof response?.error !== 'boolean') {
+      log.warn(`Expected 'error' field on IPC response.`)
+    }
+
     if (response?.error) {
       throw response
     }
 
-    return response
+    return response?.data
   } catch (error) {
     return new Promise((_, reject) => reject(error))
   }


### PR DESCRIPTION
If an error is thrown as a result of executing a handler on the main process, a response is returned across the IPC bridge with an object containing `{ error: true }`. Then on the renderer side, in the `invoke` util, the function watches for truthy values of `error`, and if it sees one, it throws the response.

However, in the snapshot manager, we return objects that include an `error` field, which ends up getting thrown by the `invoke` util. This is probably not intended behavior -- I'd lean toward establishing a pattern where unrecoverable or unintended errors are thrown, and recoverable errors are returned on the response body.

To avoid this, I wrapped successful responses in `{ error: false, data: object }` and returned the response body on the `data` field instead.