### PR TITLE
Fix display of snapshot errors

### DIFF
--- a/electron/ironfish/SnapshotManager.ts
+++ b/electron/ironfish/SnapshotManager.ts
@@ -70,8 +70,7 @@ class SnapshotManager
     if (manifest.database_version > VERSION_DATABASE_CHAIN) {
       return {
         hasError: true,
-        error:
-          'Snapshot is used more actual database version. Please try to update application.',
+        error: `The snapshot's database version is not compatible with the app. Please try to update the app or sync from peers.`,
       }
     }
 

--- a/src/components/Navbar/StatusBar/SnapshotRequirement.tsx
+++ b/src/components/Navbar/StatusBar/SnapshotRequirement.tsx
@@ -1,20 +1,9 @@
-import { FC, useState } from 'react'
-import sizeFormat from 'byte-size'
+import { FC } from 'react'
 import { chakra } from '@ironfish/ui-kit'
-import useSnapshotManifest from 'Hooks/snapshot/useSnapshotManifest'
-import SnapshotDownloadModal from 'Components/Snapshot/SnapshotDownloadModal'
-import { formatRemainingTime } from 'Utils/remainingTimeFormat'
-import NodeStatusResponse from 'Types/NodeStatusResponse'
-import { useDataSync } from 'Providers/DataSyncProvider'
 
 const SnapshotRequirement: FC<{
-  data: NodeStatusResponse | undefined
   isMinified: boolean
-}> = ({ data, isMinified }) => {
-  const [open, setOpen] = useState(true)
-  const [manifest] = useSnapshotManifest()
-  const { requiredSnapshot } = useDataSync()
-
+}> = ({ isMinified }) => {
   return (
     <>
       <chakra.h5
@@ -24,21 +13,6 @@ const SnapshotRequirement: FC<{
       >
         Choosing how to sync the chain
       </chakra.h5>
-      <SnapshotDownloadModal
-        isOpen={open && requiredSnapshot}
-        onClose={() => setOpen(false)}
-        onConfirm={() => {
-          setOpen(false)
-        }}
-        size={sizeFormat(manifest?.file_size).toString()}
-        estimateTime={formatRemainingTime(
-          ((Number(manifest?.block_sequence || 0) -
-            Number(data?.blockchain?.head || 0)) *
-            1000) /
-            (data?.blockSyncer?.syncing?.speed || 1)
-        )}
-        manifest={manifest}
-      />
     </>
   )
 }

--- a/src/components/Navbar/StatusBar/index.tsx
+++ b/src/components/Navbar/StatusBar/index.tsx
@@ -16,7 +16,7 @@ import { StatusItem } from './StatusItem'
 import NodeSyncStatus from './NodeSyncStatus'
 
 const ActiveStatus: FC<FlexProps> = props => {
-  const { synced, accountsSynced, data, requiredSnapshot, sync } = useDataSync()
+  const { synced, data, requiredSnapshot, sync } = useDataSync()
   const { status } = useSnapshotStatus()
   const small = useBreakpointValue({ base: true, sm: false })
   const download = useMemo(
@@ -49,9 +49,7 @@ const ActiveStatus: FC<FlexProps> = props => {
         display={requiredSnapshot && !download ? 'flex' : 'none'}
         style="warning"
       >
-        {isMinified => (
-          <SnapshotRequirement isMinified={isMinified} data={data} />
-        )}
+        {isMinified => <SnapshotRequirement isMinified={isMinified} />}
       </StatusItem>
       <StatusItem
         display={requiredSnapshot || download ? 'none' : 'flex'}

--- a/src/components/Snapshot/SnapshotDownloadModal.tsx
+++ b/src/components/Snapshot/SnapshotDownloadModal.tsx
@@ -14,8 +14,11 @@ import {
 } from '@ironfish/ui-kit'
 import { useSnapshotStatus } from 'Providers/SnapshotProvider'
 import { FC, useCallback, useEffect, useState } from 'react'
-import { SnapshotManifest } from 'Types/IronfishManager/IIronfishSnapshotManager'
-import { log } from 'electron-log'
+import {
+  SnapshotManifest,
+  SnapshotProgressStatus,
+} from 'Types/IronfishManager/IIronfishSnapshotManager'
+import log from 'electron-log'
 
 const SnapshotDownloadModal: FC<
   Omit<ModalProps, 'children'> & {
@@ -23,42 +26,33 @@ const SnapshotDownloadModal: FC<
     onConfirm: () => void
   }
 > = ({ onConfirm, manifest, ...props }) => {
-  const { checkPath, start } = useSnapshotStatus()
+  const { checkPath, start, status } = useSnapshotStatus()
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
-  const [byDefault, setByDefault] = useState(true)
+
+  const displayError = status?.error ?? error
 
   const handleDownload = useCallback(async () => {
     setLoading(true)
-    if (byDefault) {
+    try {
       await start()
-      onConfirm()
+    } catch (e) {
+      log.error(String(e))
+      setError(String(e))
+    } finally {
       setLoading(false)
-      return
     }
-
-    const path = await window.selectFolder()
-    if (!path) {
-      setLoading(false)
-      return
-    }
-
-    const check = await checkPath(manifest, path)
-    if (check.hasError) {
-      setLoading(false)
-      setError(check.error)
-      return
-    }
-
-    await start(path)
-    onConfirm()
-    setLoading(false)
-  }, [manifest, byDefault])
+  }, [manifest])
 
   const handleSyncing = useCallback(async () => {
     window.IronfishManager.snapshot.decline()
-    onConfirm()
-  }, [manifest, byDefault])
+  }, [manifest])
+
+  useEffect(() => {
+    if (status && status.status !== SnapshotProgressStatus.NOT_STARTED) {
+      onConfirm()
+    }
+  }, [status])
 
   useEffect(() => {
     if (!manifest) {
@@ -66,11 +60,17 @@ const SnapshotDownloadModal: FC<
     }
 
     setLoading(true)
-    checkPath(manifest).then(result => {
-      setLoading(false)
-      setError(result.error)
-      setByDefault(!result.hasError)
-    })
+    checkPath(manifest)
+      .then(result => {
+        setError(result.error)
+      })
+      .catch(e => {
+        log.error(String(e))
+        setError(String(e))
+      })
+      .finally(() => {
+        setLoading(false)
+      })
   }, [manifest])
 
   return (
@@ -91,14 +91,16 @@ const SnapshotDownloadModal: FC<
               from other users, contributing to network decentralization. While
               it may take longer, it strengthens the network's resilience.{' '}
             </chakra.h4>
-            {error && <chakra.h4 color={NAMED_COLORS.RED}>{error}</chakra.h4>}
+            {displayError && (
+              <chakra.h4 color={NAMED_COLORS.RED}>{displayError}</chakra.h4>
+            )}
           </ModalBody>
           <ModalFooter justifyContent="flex-start">
             <Button
               marginRight="16px"
               variant="primary"
               size="medium"
-              isDisabled={loading || error}
+              isDisabled={loading || displayError}
               onClick={handleDownload}
               leftIcon={loading ? <Spinner /> : null}
             >

--- a/src/components/Snapshot/SnapshotDownloadModal.tsx
+++ b/src/components/Snapshot/SnapshotDownloadModal.tsx
@@ -15,18 +15,17 @@ import {
 import { useSnapshotStatus } from 'Providers/SnapshotProvider'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { SnapshotManifest } from 'Types/IronfishManager/IIronfishSnapshotManager'
+import { log } from 'electron-log'
 
 const SnapshotDownloadModal: FC<
   Omit<ModalProps, 'children'> & {
     manifest: SnapshotManifest
-    size: string
-    estimateTime: string
     onConfirm: () => void
   }
-> = ({ size, estimateTime, onConfirm, manifest, ...props }) => {
+> = ({ onConfirm, manifest, ...props }) => {
   const { checkPath, start } = useSnapshotStatus()
   const [error, setError] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
   const [byDefault, setByDefault] = useState(true)
 
   const handleDownload = useCallback(async () => {
@@ -62,11 +61,16 @@ const SnapshotDownloadModal: FC<
   }, [manifest, byDefault])
 
   useEffect(() => {
-    manifest &&
-      checkPath(manifest).then(result => {
-        setLoading(false)
-        setByDefault(!result.hasError)
-      })
+    if (!manifest) {
+      return
+    }
+
+    setLoading(true)
+    checkPath(manifest).then(result => {
+      setLoading(false)
+      setError(result.error)
+      setByDefault(!result.hasError)
+    })
   }, [manifest])
 
   return (
@@ -94,7 +98,7 @@ const SnapshotDownloadModal: FC<
               marginRight="16px"
               variant="primary"
               size="medium"
-              disabled={loading}
+              isDisabled={loading || error}
               onClick={handleDownload}
               leftIcon={loading ? <Spinner /> : null}
             >

--- a/src/components/Snapshot/SnapshotDownloadModal.tsx
+++ b/src/components/Snapshot/SnapshotDownloadModal.tsx
@@ -100,7 +100,7 @@ const SnapshotDownloadModal: FC<
               marginRight="16px"
               variant="primary"
               size="medium"
-              isDisabled={loading || displayError}
+              isDisabled={loading}
               onClick={handleDownload}
               leftIcon={loading ? <Spinner /> : null}
             >

--- a/src/components/Snapshot/SnapshotStatusModal.tsx
+++ b/src/components/Snapshot/SnapshotStatusModal.tsx
@@ -44,7 +44,7 @@ const getContent = (status: SnapshotProgressStatus) => {
       return {
         title: 'Downloading Snapshot',
         description:
-          'Downloading snapshot is the fastest way to update your chain database.',
+          'Downloading a snapshot is the fastest way to update your chain database.',
       }
     case SnapshotProgressStatus.CLEARING_CHAIN_DB:
     case SnapshotProgressStatus.CLEARING_TEMP_DATA:
@@ -52,7 +52,7 @@ const getContent = (status: SnapshotProgressStatus) => {
       return {
         title: 'Updating Chain Database',
         description:
-          "Since you’ve downloaded our snapshot, we need to clear and update your chain database. Please, don't close application.",
+          "Now that you’ve downloaded a snapshot, we need to replace your chain database. Please, don't close the application.",
       }
     default:
       return { title: '', description: '' }

--- a/src/routes/PageLayout.tsx
+++ b/src/routes/PageLayout.tsx
@@ -10,11 +10,8 @@ import {
 import SnapshotDownloadModal from 'Components/Snapshot/SnapshotDownloadModal'
 import useSnapshotManifest from 'Hooks/snapshot/useSnapshotManifest'
 import { useDataSync } from 'Providers/DataSyncProvider'
-import { FC, useState } from 'react'
-import sizeFormat from 'byte-size'
+import { FC, useEffect, useState } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
-import NodeStatusResponse from 'Types/NodeStatusResponse'
-import { formatRemainingTime } from 'Utils/remainingTimeFormat'
 import Navbar from '../components/Navbar'
 import {
   DARK_COLORS,
@@ -25,10 +22,16 @@ import { ROUTES } from '../routes'
 
 const DownloadSnapshotMessage: FC<{
   show: boolean
-  data: NodeStatusResponse
-}> = ({ show, data }) => {
+}> = ({ show }) => {
   const [open, setOpen] = useState(false)
   const [manifest] = useSnapshotManifest()
+
+  useEffect(() => {
+    if (show) {
+      setOpen(true)
+    }
+  }, [show])
+
   return (
     <Collapse
       in={show}
@@ -85,13 +88,6 @@ const DownloadSnapshotMessage: FC<{
           onConfirm={() => {
             setOpen(false)
           }}
-          size={sizeFormat(manifest?.file_size).toString()}
-          estimateTime={formatRemainingTime(
-            ((Number(manifest?.block_sequence || 0) -
-              Number(data?.blockchain?.head || 0)) *
-              1000) /
-              (data?.blockSyncer?.syncing?.speed || 1)
-          )}
           manifest={manifest}
         />
       </Flex>
@@ -101,14 +97,13 @@ const DownloadSnapshotMessage: FC<{
 
 export function PageLayout() {
   const {
-    data,
     requiredSnapshot,
     updates: { status, ignore, install },
   } = useDataSync()
   const location = useLocation()
   return (
     <>
-      <DownloadSnapshotMessage show={requiredSnapshot} data={data} />
+      <DownloadSnapshotMessage show={requiredSnapshot} />
       <Flex
         className="App"
         justifyContent="center"


### PR DESCRIPTION
Fixes a few problems with error display when downloading snapshots:

* Errors that happen during `start` would cause the download modal to close anyway without displaying the error. Now the modal stays open until a choice is made.
* Errors from `checkPath` weren't actually set.
* Removed code for choosing a path -- we can add that as a feature in the future, but the code path didn't work and downloaded to the node's temp directory instead.
* Cleaned up the grammar on displayed error messages
* There were two instances of the SnapshotDownloadModal -- This doesn't seem to be necessary in the current design, from what I can tell.
* Fixed disabling the button while the loading spinner is active
* Removed some unused props from SnapshotDownloadModal