### PR TITLE
Remove npm install from packageAfterPrune

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const spawn = require('cross-spawn')
 require('dotenv').config()
 const { exec } = require('child_process')
 
@@ -104,17 +103,6 @@ const COMMON_CONFIG = {
             }
           }
         }
-      }
-    },
-    packageAfterPrune: (forgeConfig, buildPath) => {
-      try {
-        spawn.sync('npm', ['install'], {
-          cwd: buildPath,
-          stdio: 'inherit',
-        })
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e)
       }
     },
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "check-disk-space": "^3.3.1",
     "copy-webpack-plugin": "^11.0.0",
     "cross-env": "^7.0.3",
-    "cross-spawn": "^7.0.3",
     "css-loader": "^6.0.0",
     "del": "^7.0.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
The 1.0.2 build was including node_modules and devDependencies, which was also causing code signing to fail on macOS. I'm not certain why it would be happening now and not on prior builds, but I suspect the packageAfterPrune step of the build might have been causing it. Removing this step and triggering a build caused the build to complete successfully.