### PR TITLE
Fix calculation of fees in multi-asset transactions

### DIFF
--- a/src/routes/Send/Send.tsx
+++ b/src/routes/Send/Send.tsx
@@ -170,16 +170,29 @@ const Send: FC = () => {
     if (balance?.available === BigInt(0)) {
       return setError(HAS_PENDING_TRANSACTIONS)
     }
-    if (balance?.confirmed === BigInt(0)) {
-      return setError(NOT_ENOUGH_FUNDS)
-    }
+
+    const amountInIron = decodeIron(amount || 0)
     const fee = selectedFee?.value || BigInt(0)
-    const ironAmount = decodeIron(amount || 0)
-    if (balance?.confirmed < ironAmount + fee) {
+
+    const totalIron =
+      balance?.asset.id === account?.balances.default.asset.id
+        ? amountInIron + fee
+        : fee
+
+    if (
+      account?.balances.default.confirmed < totalIron ||
+      balance?.confirmed < amountInIron
+    ) {
       return setError(NOT_ENOUGH_FUNDS)
     }
     setError('')
-  }, [balance?.available, balance?.confirmed, amount, selectedFee?.value])
+  }, [
+    balance?.asset?.id,
+    balance?.available,
+    balance?.confirmed,
+    amount,
+    selectedFee?.value,
+  ])
 
   const hasInvalidData = useMemo(() => {
     return !(


### PR DESCRIPTION
The total amount + fees was being compared to the balance of the chosen asset, but fees should only ever apply to the $IRON balance. This changes the check to error in these cases:

* $IRON balance is less than amount + fee if $IRON is chosen
* $IRON balance is less than fee if $IRON is not chosen
* chosen asset balance is less than amount
