### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Iron Fish Node App",
   "main": ".webpack/main",
   "repository": "https://github.com/iron-fish/node-app",


### PR DESCRIPTION
Bump to 1.0.3 for a hotfix release to fix sending multi-asset transactions.