### PR TITLE
Remove react-flag-kit

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -114,7 +114,6 @@ export class IronFishManager implements IIronfishManager {
         agent: peer.agent,
         name: peer.name,
         address: peer.address,
-        country: null,
         port: peer.port,
         error: peer.error !== null ? String(peer.error) : null,
         connections: connections,

--- a/forge.config.js
+++ b/forge.config.js
@@ -114,8 +114,6 @@ const ENV_CONFIGS = {
         name: '@electron-forge/plugin-webpack',
         config: {
           mainConfig: './webpack/dev/main.config.js',
-          devContentSecurityPolicy:
-            "connect-src 'self' https://cdn.jsdelivr.net/gh/umidbekk/react-flag-kit@1/assets/* 'unsave-eval'",
           renderer: {
             config: './webpack/common/renderer.config.js',
             entryPoints: [
@@ -139,8 +137,6 @@ const ENV_CONFIGS = {
         name: '@electron-forge/plugin-webpack',
         config: {
           mainConfig: './webpack/demo/main.config.js',
-          devContentSecurityPolicy:
-            "connect-src 'self' https://cdn.jsdelivr.net/gh/umidbekk/react-flag-kit@1/assets/* 'unsave-eval'",
           renderer: {
             config: './webpack/common/renderer.config.js',
             entryPoints: [
@@ -178,8 +174,6 @@ const ENV_CONFIGS = {
         name: '@electron-forge/plugin-webpack',
         config: {
           mainConfig: './webpack/prod/main.config.js',
-          devContentSecurityPolicy:
-            "connect-src 'self' https://cdn.jsdelivr.net/gh/umidbekk/react-flag-kit@1/assets/* 'unsave-eval'",
           renderer: {
             config: './webpack/common/renderer.config.js',
             entryPoints: [

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "prettier": "^2.6.2",
     "random-words": "^1.2.0",
     "react-app-rewired": "^2.2.1",
-    "react-flag-kit": "^1.1.1",
     "react-markdown": "^8.0.6",
     "react-scripts": "^5.0.1",
     "stream-browserify": "^3.0.0",

--- a/src/data/DemoNodeManager.ts
+++ b/src/data/DemoNodeManager.ts
@@ -77,9 +77,6 @@ const PEERS: Peer[] = Array(23)
         .fill(null)
         .map(() => Math.floor((Math.random() * 1000) % 255))
         .join('.'),
-      country: ['US', 'CA', 'AR', 'BY', 'RU', 'AU', 'BE', 'GB', 'FR', 'ES'][
-        Math.floor(Math.random() * 10)
-      ],
       port: 8080,
       error: '',
       connections: 12,

--- a/src/routes/NodeOverview/NodePeers.tsx
+++ b/src/routes/NodeOverview/NodePeers.tsx
@@ -5,7 +5,6 @@ import {
   useBreakpointValue,
 } from '@ironfish/ui-kit'
 import { FC } from 'react'
-import { FlagIcon } from 'react-flag-kit'
 import useNodePeers from 'Hooks/node/useNodePeers'
 import { truncateHash } from 'Utils/hash'
 import WalletCommonTable from 'Components/WalletCommonTable'
@@ -68,13 +67,8 @@ const NodePeers: FC = () => {
           WrapperProps: {
             w: '33%',
           },
-          render: ({ address, country }) => (
+          render: ({ address }) => (
             <Flex alignItems="center">
-              {country && (
-                <Box mr="1rem" w="1.5rem">
-                  <FlagIcon code={country} size={24} />
-                </Box>
-              )}
               <Box minW="6.875rem" wordBreak="break-word">
                 {address}
               </Box>

--- a/types/Peer.ts
+++ b/types/Peer.ts
@@ -1,5 +1,5 @@
 import { PeerResponse } from '@ironfish/sdk'
 
-type Peer = Omit<PeerResponse, 'features'> & { country: string }
+type Peer = Omit<PeerResponse, 'features'>
 
 export default Peer

--- a/yarn.lock
+++ b/yarn.lock
@@ -14094,11 +14094,6 @@ react-fast-compare@3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-flag-kit@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-flag-kit/-/react-flag-kit-1.1.1.tgz#368797185bd5c406b94e641eadddf96b56aba21a"
-  integrity sha512-sgelSGSl0HxSL8lMM1TEBidgiGV2hOi+GaLNKeg10aBnL07vpwKvmfILlc1SzOdVyH48NElFyMj4NQn8F+/FHw==
-
 react-focus-lock@^2.9.2:
   version "2.9.4"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.4.tgz#4753f6dcd167c39050c9d84f9c63c71b3ff8462e"


### PR DESCRIPTION
Removes react-flag-kit and the "country" field on Peers for now, since we're not actually displaying it in the production app. This also has the side effect of fixing a console complaint about a typo in the dev environment's content security policy, which I don't think we need.

Fixes IFL-1692