### PR TITLE
Remove unused dns lookup

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -16,7 +16,6 @@ import {
 } from '@ironfish/sdk'
 import log from 'electron-log'
 import fsAsync from 'fs/promises'
-import dns from 'dns/promises'
 import { IIronfishManager } from 'Types/IronfishManager/IIronfishManager'
 import IronFishInitStatus from 'Types/IronfishInitStatus'
 import NodeStatusResponse, { NodeStatusType } from 'Types/NodeStatusResponse'
@@ -96,12 +95,6 @@ export class IronFishManager implements IIronfishManager {
       }
       if (connectionWebRTC !== '') {
         connections++
-      }
-
-      let address = peer.address
-      const ipRegexp = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/
-      if (address && !ipRegexp.test(address)) {
-        address = (await dns.lookup(address)).address
       }
 
       result.push({


### PR DESCRIPTION
I've seen a few crashes with the error message `getaddrinfo ENOTFOUND 1.main.bn.ironfish.network`. I think the SDK handles errors properly in WebSocketConnection and WebRTCConnection, since I don't think we've ever seen this from the CLI. I found this DNS lookup that seems likely to be the culprit, and since we don't use it for anything, it's easy to remove.

Fixes IFL-1693