### PR TITLE
Add RpcMemoryClient to AccountManager and replace route

### DIFF
--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -6,6 +6,7 @@ import {
   Bech32m,
   JSONUtils,
   isValidPublicAddress,
+  RpcClient,
 } from '@ironfish/sdk'
 import { v4 as uuid } from 'uuid'
 import {
@@ -35,10 +36,16 @@ class AccountManager
   implements IIronfishAccountManager
 {
   private assetManager: AssetManager
+  private rpcClient: RpcClient
 
-  constructor(node: FullNode, assetManager: AssetManager) {
+  constructor(
+    node: FullNode,
+    assetManager: AssetManager,
+    rpcClient: RpcClient
+  ) {
     super(node)
     this.assetManager = assetManager
+    this.rpcClient = rpcClient
   }
 
   initEventListeners(): void {
@@ -317,13 +324,15 @@ class AccountManager
     return newAccount.serialize()
   }
 
-  async renameAccount(id: string, name: string): Promise<void> {
-    const account = this.node.wallet.getAccount(id)
-    if (!account) {
-      throw new Error(`Account with id=${id} was not found.`)
+  async renameAccount(name: string, newName: string): Promise<void> {
+    try {
+      await this.rpcClient.wallet.renameAccount({
+        account: name,
+        newName,
+      })
+    } catch (e) {
+      throw new Error(e.codeMessage || e.message)
     }
-
-    await account.setName(name)
   }
 }
 

--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -13,6 +13,9 @@ import {
   InternalOptions,
   HOST_FILE_NAME,
   DatabaseIsLockedError,
+  RpcClient,
+  RpcMemoryClient,
+  ALL_API_NAMESPACES,
 } from '@ironfish/sdk'
 import log from 'electron-log'
 import fsAsync from 'fs/promises'
@@ -39,6 +42,7 @@ export class IronFishManager implements IIronfishManager {
   protected initStatus: IronFishInitStatus = IronFishInitStatus.NOT_STARTED
   protected sdk: IronfishSdk
   protected node: FullNode
+  protected rpcClient: RpcClient
   accounts: AccountManager
   assets: AssetManager
   nodeSettings: NodeSettingsManager
@@ -195,6 +199,10 @@ export class IronFishManager implements IIronfishManager {
       privateIdentity: this.getPrivateIdentity(),
       autoSeed: true,
     })
+    this.rpcClient = new RpcMemoryClient(
+      this.node.logger,
+      this.node.rpc.getRouter(ALL_API_NAMESPACES)
+    )
     log.log('Node reset complete')
   }
 
@@ -226,6 +234,10 @@ export class IronFishManager implements IIronfishManager {
       privateIdentity: privateIdentity,
       autoSeed: true,
     })
+    this.rpcClient = new RpcMemoryClient(
+      this.node.logger,
+      this.node.rpc.getRouter(ALL_API_NAMESPACES)
+    )
 
     await this.checkForMigrations()
 
@@ -267,7 +279,7 @@ export class IronFishManager implements IIronfishManager {
     await this.node.internal.save()
 
     this.assets = new AssetManager(this.node)
-    this.accounts = new AccountManager(this.node, this.assets)
+    this.accounts = new AccountManager(this.node, this.assets, this.rpcClient)
     this.transactions = new TransactionManager(this.node, this.assets)
     this.nodeSettings = new NodeSettingsManager(this.node)
     this.snapshot = new SnapshotManager(this.node)

--- a/src/data/DemoAccountsManager.ts
+++ b/src/data/DemoAccountsManager.ts
@@ -452,8 +452,9 @@ class DemoAccountsManager implements IIronfishAccountManager {
     return this.create(createParams.name)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async renameAccount(_id: string, _name: string): Promise<void> {}
+  async renameAccount(_name: string, _newName: string): Promise<void> {
+    // Do nothing
+  }
 }
 
 export default DemoAccountsManager

--- a/src/hooks/accounts/useAccount.ts
+++ b/src/hooks/accounts/useAccount.ts
@@ -8,11 +8,14 @@ const useAccount = (id: string) => {
   const loadAccount = (accountId: string) =>
     promiseWrapper(window.IronfishManager.accounts.get(accountId))
 
-  const updateAccount = useCallback((identity: string, name: string) => {
-    window.IronfishManager.accounts
-      .renameAccount(identity, name)
-      .then(() => loadAccount(identity))
-  }, [])
+  const updateAccount = useCallback(
+    (identity: string, name: string, newName: string) => {
+      return window.IronfishManager.accounts
+        .renameAccount(name, newName)
+        .then(() => loadAccount(identity))
+    },
+    []
+  )
 
   const exportAccount = useCallback(
     (identity: string, encoded?: boolean) =>

--- a/src/routes/Account/Settings/Settings.tsx
+++ b/src/routes/Account/Settings/Settings.tsx
@@ -48,7 +48,11 @@ const Information: FC = memo(() => {
 
 interface AccountSettingsProps {
   account: Account
-  updateAccount: (identity: string, name: string) => void
+  updateAccount: (
+    identity: string,
+    name: string,
+    newName: string
+  ) => Promise<void>
   deleteAccount: (identity: string) => Promise<void>
 }
 
@@ -159,10 +163,9 @@ const AccountSettings: FC<AccountSettingsProps> = ({
             mr="2rem"
             isDisabled={name === account.name}
             onClick={() => {
-              Promise.all([
-                updateAccount(account.id, name),
-                // updateSettings(account.id, currency.value),
-              ]).then(() => toast({ title: 'Account Details Updated' }))
+              updateAccount(account.id, account.name, name)
+                .then(() => toast({ title: 'Account Details Updated' }))
+                .catch((e: Error) => toast({ title: e.message }))
             }}
           >
             Save Changes

--- a/types/IronfishManager/IIronfishAccountManager.ts
+++ b/types/IronfishManager/IIronfishAccountManager.ts
@@ -40,6 +40,6 @@ export interface IIronfishAccountManager {
   isValidPublicAddress: (address: string) => Promise<boolean>
   list: (search?: string, sort?: SortType) => Promise<CutAccount[]>
   prepareAccount: () => Promise<AccountCreateParams>
-  renameAccount: (id: string, name: string) => Promise<void>
+  renameAccount: (name: string, newName: string) => Promise<void>
   submitAccount: (createParams: AccountValue) => Promise<Account>
 }


### PR DESCRIPTION
Adds an RpcMemoryClient to AccountManager and replaces the account renaming with an RPC call.

I think it'd be preferable to expose the RPC client directly to the frontend, but I wanted to try out what the interaction would be like between the frontend and the RPC layer. We could possibly go about refactoring to use the RPC Client by rewriting the Managers to use the RPC client, then exposing the RPC client to the frontend, then moving the manager code into the hooks on the frontend.

Of note, the RpcMemoryClient throws errors that have a `codeMessage` field, and that's usually what we'd want to display to users rather than `Error.message`.

As far as what will need to change in AccountManager to work with the RPC client instead, we'll want to prefer account names rather than the internal IDs to distinguish accounts. We'll also want to use different object types for accounts, since generally we won't have fields like the view keys unless exporting the account.

Fixes IFL-1699