### PR TITLE
fix: Reset accounts when resetting node via settings

### DIFF
--- a/electron/ironfish/IronFishManager.ts
+++ b/electron/ironfish/IronFishManager.ts
@@ -158,6 +158,13 @@ export class IronFishManager implements IIronfishManager {
     await walletDb.db.close()
   }
 
+  private async resetAccounts(): Promise<void> {
+    await this.node.wallet.open()
+    for (const account of this.node.wallet.listAccounts()) {
+      await this.node.wallet.resetAccount(account)
+    }
+  }
+
   // used to reset node if datadir exists but is incompatible with mainnet
   async resetNode(): Promise<void> {
     log.log('Resetting node')
@@ -195,6 +202,7 @@ export class IronFishManager implements IIronfishManager {
       privateIdentity: this.getPrivateIdentity(),
       autoSeed: true,
     })
+    await this.resetAccounts()
     log.log('Node reset complete')
   }
 

--- a/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
+++ b/src/routes/NodeOverview/NodeSettings/NodeSettings.tsx
@@ -81,10 +81,9 @@ const NodeSettings: FC = () => {
     saveSettings(nodeSettings).then(() => toast({ title: 'Settings saved' }))
   }
 
-  const handleResetNode = () => {
-    window.IronfishManager.resetNode().then(() => {
-      window.IronfishManager.restartApp()
-    })
+  const handleResetNode = async () => {
+    await window.IronfishManager.resetNode()
+    window.IronfishManager.restartApp()
   }
 
   const hasNoChanges = useMemo(


### PR DESCRIPTION
Resets accounts when resetting the node. If this is not done, the app gets stuck in an unusable state due to accounts being ahead of the chain.