### PR TITLE
Fix initStorageCallbacks causing ipc handler to try to return unserializable data

### DIFF
--- a/electron/common/initStorage.ts
+++ b/electron/common/initStorage.ts
@@ -13,49 +13,49 @@ const storages: Record<string, AbstractStorage<Entity>> = {
 
 function initStorageCallbacks(ipcMain: IpcMain) {
   Object.entries(storages).forEach(([storageName, storage]) => {
-    ipcMain.handle(storageName + '-list', (e, searchTerm, sort) => {
+    ipcMain.handle(storageName + '-list', async (e, searchTerm, sort) => {
       try {
-        return { error: false, data: storage.list(searchTerm, sort) }
+        return { error: false, data: await storage.list(searchTerm, sort) }
       } catch (error) {
         return handleError(error)
       }
     })
 
-    ipcMain.handle(storageName + '-get', (e, identity) => {
+    ipcMain.handle(storageName + '-get', async (e, identity) => {
       try {
-        return { error: false, data: storage.get(identity) }
+        return { error: false, data: await storage.get(identity) }
       } catch (error) {
         return handleError(error)
       }
     })
 
-    ipcMain.handle(storageName + '-add', (e, entity) => {
+    ipcMain.handle(storageName + '-add', async (e, entity) => {
       try {
-        return { error: false, data: storage.add(entity) }
+        return { error: false, data: await storage.add(entity) }
       } catch (error) {
         return handleError(error)
       }
     })
 
-    ipcMain.handle(storageName + '-update', (e, identity, entity) => {
+    ipcMain.handle(storageName + '-update', async (e, identity, entity) => {
       try {
-        return { error: false, data: storage.update(identity, entity) }
+        return { error: false, data: await storage.update(identity, entity) }
       } catch (error) {
         return handleError(error)
       }
     })
 
-    ipcMain.handle(storageName + '-delete', (e, identity) => {
+    ipcMain.handle(storageName + '-delete', async (e, identity) => {
       try {
-        return { error: false, data: storage.delete(identity) }
+        return { error: false, data: await storage.delete(identity) }
       } catch (error) {
         return handleError(error)
       }
     })
 
-    ipcMain.handle(storageName + '-find', (e, fields) => {
+    ipcMain.handle(storageName + '-find', async (e, fields) => {
       try {
-        return { error: false, data: storage.find(fields) }
+        return { error: false, data: await storage.find(fields) }
       } catch (error) {
         return handleError(error)
       }

--- a/electron/storage/AddressBookStorage.ts
+++ b/electron/storage/AddressBookStorage.ts
@@ -57,7 +57,7 @@ class AddressBookStorage extends AbstractStorage<Contact> {
     })
   }
 
-  async list(searchTerm: string, sort: SortType): Promise<Contact[]> {
+  list(searchTerm: string, sort: SortType): Promise<Contact[]> {
     return new Promise((resolve, reject) => {
       this.storage
         .find({

--- a/electron/storage/AddressBookStorage.ts
+++ b/electron/storage/AddressBookStorage.ts
@@ -57,7 +57,7 @@ class AddressBookStorage extends AbstractStorage<Contact> {
     })
   }
 
-  list(searchTerm: string, sort: SortType): Promise<Contact[]> {
+  async list(searchTerm: string, sort: SortType): Promise<Contact[]> {
     return new Promise((resolve, reject) => {
       this.storage
         .find({

--- a/src/hooks/addressBook/useAddressBook.ts
+++ b/src/hooks/addressBook/useAddressBook.ts
@@ -3,21 +3,24 @@ import useAsyncDataWrapper from 'Hooks/useAsyncDataWrapper'
 import SortType from 'Types/SortType'
 import Contact from 'Types/Contact'
 
-const useAddressBook = (searchTerm?: string, sort?: SortType) => {
+const useAddressBook = (searchTerm?: string, sort: SortType = SortType.ASC) => {
   const [result, promiseWrapper] = useAsyncDataWrapper<Contact[]>()
+
   const addContact = useCallback(
-    (name: string, address: string): Promise<Contact> =>
-      window.AddressBookStorage.add({ name, address }).then(contact => {
+    (name: string, address: string): Promise<Contact> => {
+      return window.AddressBookStorage.add({ name, address }).then(contact => {
         loadAddressBook()
         return contact
-      }),
+      })
+    },
     []
   )
 
-  const reloadContacts = useCallback(() => loadAddressBook(), [])
+  const loadAddressBook = () => {
+    return promiseWrapper(window.AddressBookStorage.list(searchTerm, sort))
+  }
 
-  const loadAddressBook = () =>
-    promiseWrapper(window.AddressBookStorage.list(searchTerm, sort))
+  const reloadContacts = useCallback(() => loadAddressBook(), [])
 
   useEffect(() => {
     loadAddressBook()

--- a/src/routes/AddressBook/AddressBook.tsx
+++ b/src/routes/AddressBook/AddressBook.tsx
@@ -79,7 +79,7 @@ const ContactSearch: FC<{ contactsAmount: number }> = ({ contactsAmount }) => {
   const { synced } = useDataSync()
   const [{ data: contacts, loaded }, , reloadContacts] = useAddressBook(
     $searchTerm,
-    $sortOrder
+    $sortOrder ?? SortType.ASC
   )
   const contactsLoaded = useDeferredValue(loaded)
 


### PR DESCRIPTION
Fixes issue that was causing the Address Book to break because `initStorageCallbacks` was causing the IPC bridge to send promises over the wire, which is not allowed.