### PR TITLE
Add default label if there's no node name

### DIFF
--- a/src/routes/NodeOverview/NodeStatus.tsx
+++ b/src/routes/NodeOverview/NodeStatus.tsx
@@ -85,7 +85,9 @@ const NodeStatus: FC<NodeStatusProps> = ({ pauseTracking, ...props }) => {
               startColor="#F3C174"
               endColor="#F1B75E"
             >
-              <chakra.h3 mb="1rem">{data?.node.nodeName}</chakra.h3>
+              <chakra.h3 mb="1rem">
+                {data?.node.nodeName || 'Node Overview'}
+              </chakra.h3>
             </Skeleton>
             <HStack spacing="4rem">
               <VStack spacing="1rem" align="flex-start">


### PR DESCRIPTION
If the user doesn't have a node name set, show a default label for the Node Overview page
