### PR TITLE
Add required upgrade bar to top of app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import Updates from 'Routes/Updates/Updates'
 import Update from 'Routes/Updates/Update'
 import { ReleaseNotesProviderWrapper } from 'Providers/ReleaseNotesProvider'
 import Telemetry from 'Routes/Onboarding/Telemetry'
+import Upgrade from 'Routes/Upgrade'
 
 const breakpoints = {
   xs: '46.875rem', //750px
@@ -49,36 +50,41 @@ function App() {
         <ElectronThemeChangeHandler />
         <HashRouter>
           <Routes>
-            <Route element={<Initializing />}>
-              <Route element={<Providers />}>
-                <Route path={ROUTES.BASE} />
-                <Route element={<CreateLayout />}>
-                  <Route path={ROUTES.TELEMETRY} element={<Telemetry />} />
-                  <Route path={ROUTES.ONBOARDING} element={<Action />} />
-                  <Route path={ROUTES.CREATE} element={<CreateAccount />} />
-                  <Route path={ROUTES.IMPORT} element={<ImportAccount />} />
-                </Route>
-                <Route element={<PageLayout />}>
-                  <Route path={ROUTES.ACCOUNT} element={<AccountDetails />} />
-                  <Route path={ROUTES.ACCOUNTS} element={<Accounts />} />
-                  <Route path={ROUTES.RECEIVE} element={<ReceiveMoney />} />
-                  <Route path={ROUTES.SEND} element={<Send />} />
-                  <Route path={ROUTES.ADDRESS_BOOK} element={<AddressBook />} />
-                  <Route
-                    path={ROUTES.TRANSACTION}
-                    element={<TransactionOverview />}
-                  />
-                  <Route
-                    path={ROUTES.ADDRESS_BOOK_DETAILS}
-                    element={<AddressDetails />}
-                  />
-                  {/* <Route path={ROUTES.RESOURCES} element={null} /> */}
-                  <Route path={ROUTES.NODE} element={<NodeOverview />} />
-                  <Route element={<ReleaseNotesProviderWrapper />}>
-                    <Route path={ROUTES.UPDATE} element={<Update />} />
-                    <Route path={ROUTES.UPDATES} element={<Updates />} />
+            <Route element={<Upgrade />}>
+              <Route element={<Initializing />}>
+                <Route element={<Providers />}>
+                  <Route path={ROUTES.BASE} />
+                  <Route element={<CreateLayout />}>
+                    <Route path={ROUTES.TELEMETRY} element={<Telemetry />} />
+                    <Route path={ROUTES.ONBOARDING} element={<Action />} />
+                    <Route path={ROUTES.CREATE} element={<CreateAccount />} />
+                    <Route path={ROUTES.IMPORT} element={<ImportAccount />} />
                   </Route>
-                  {/* <Route path={ROUTES.MINER} element={<Miner />} /> */}
+                  <Route element={<PageLayout />}>
+                    <Route path={ROUTES.ACCOUNT} element={<AccountDetails />} />
+                    <Route path={ROUTES.ACCOUNTS} element={<Accounts />} />
+                    <Route path={ROUTES.RECEIVE} element={<ReceiveMoney />} />
+                    <Route path={ROUTES.SEND} element={<Send />} />
+                    <Route
+                      path={ROUTES.ADDRESS_BOOK}
+                      element={<AddressBook />}
+                    />
+                    <Route
+                      path={ROUTES.TRANSACTION}
+                      element={<TransactionOverview />}
+                    />
+                    <Route
+                      path={ROUTES.ADDRESS_BOOK_DETAILS}
+                      element={<AddressDetails />}
+                    />
+                    {/* <Route path={ROUTES.RESOURCES} element={null} /> */}
+                    <Route path={ROUTES.NODE} element={<NodeOverview />} />
+                    <Route element={<ReleaseNotesProviderWrapper />}>
+                      <Route path={ROUTES.UPDATE} element={<Update />} />
+                      <Route path={ROUTES.UPDATES} element={<Updates />} />
+                    </Route>
+                    {/* <Route path={ROUTES.MINER} element={<Miner />} /> */}
+                  </Route>
                 </Route>
               </Route>
             </Route>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -93,8 +93,6 @@ export const Navbar: FC<FlexProps> = props => {
   return (
     <Flex
       bg="inherit"
-      height="100%"
-      maxHeight="100vh"
       p="3rem 1rem 1rem"
       w={isOpen ? '16.4375rem' : '5.5rem'}
       transition="width 0.5s ease-in-out"

--- a/src/routes/PageLayout.tsx
+++ b/src/routes/PageLayout.tsx
@@ -107,12 +107,10 @@ export function PageLayout() {
       <Flex
         className="App"
         justifyContent="center"
-        minHeight={requiredSnapshot ? 'calc(100vh - 3rem)' : '100vh'}
+        flex={1}
+        overflow="auto"
       >
-        <Navbar
-          top={requiredSnapshot ? '3rem' : '0'}
-          height={requiredSnapshot ? 'calc(100vh - 3rem)' : '100vh'}
-        />
+        <Navbar />
         <Box w="100%">
           <ScaleFade
             in={true}

--- a/src/routes/PageLayout.tsx
+++ b/src/routes/PageLayout.tsx
@@ -104,12 +104,7 @@ export function PageLayout() {
   return (
     <>
       <DownloadSnapshotMessage show={requiredSnapshot} />
-      <Flex
-        className="App"
-        justifyContent="center"
-        flex={1}
-        overflow="auto"
-      >
+      <Flex className="App" justifyContent="center" flex={1} overflow="auto">
         <Navbar />
         <Box w="100%">
           <ScaleFade

--- a/src/routes/Upgrade.tsx
+++ b/src/routes/Upgrade.tsx
@@ -1,0 +1,48 @@
+import { Flex, Text, Button, HStack } from '@ironfish/ui-kit'
+import ArrowRight from 'Svgx/ArrowRight'
+import { FC } from 'react'
+import { Outlet } from 'react-router-dom'
+import { BLOCK_EXPLORER_URL } from 'Utils/constants'
+
+const Upgrade: FC = () => {
+  return (
+    <Flex height="100vh" flexDirection="column">
+      <Flex
+        position="sticky"
+        width="100%"
+        bg="linear-gradient(90deg, #FFC2E8 0%, #DE83F0 100%)"
+        py="16px"
+        px="10px"
+        top="0"
+        justifyContent="center"
+      >
+        <HStack gap="16px">
+          <Text>
+            This version of the app will no longer be updated. Please uninstall
+            and download Node App 2.0.
+          </Text>
+          <Button
+            variant="primary"
+            bg="transparent"
+            borderRadius="4rem"
+            color="black"
+            borderColor="black"
+            flexShrink="0"
+            rightIcon={<ArrowRight />}
+            _hover={{
+              bg: 'rgba(255, 255, 255, 0.75)',
+            }}
+            onClick={() =>
+              window.IronfishManager.openLink(`${BLOCK_EXPLORER_URL}`)
+            }
+          >
+            Download
+          </Button>
+        </HStack>
+      </Flex>
+      <Outlet />
+    </Flex>
+  )
+}
+
+export default Upgrade


### PR DESCRIPTION
Adds a bar to the top of the app informing users to uninstall and redownload the app. This isn't ready to merge and ship until we've actually published the new app and updated the website though.

I wanted to put the bar at the very top level of the app, so had to shuffle around the layout a bit. Ideally even if the app eventually gets too outdated to initialize the Iron Fish SDK, the bar will still appear on all screens.  

Here's what it looks like:

![image](https://github.com/iron-fish/node-app/assets/767083/d73bbc89-852f-4558-ade2-be825d4a66cd)


Fixes IFL-1829
Fixes IFL-1834
