### PR TITLE
fix: Generate ID when importing account as JSON

### DIFF
--- a/electron/ironfish/AccountManager.ts
+++ b/electron/ironfish/AccountManager.ts
@@ -175,7 +175,10 @@ class AccountManager
   }
 
   async import(account: Omit<AccountValue, 'rescan'>): Promise<AccountValue> {
-    const importedAccount = await this.node.wallet.importAccount(account)
+    const importedAccount = await this.node.wallet.importAccount({
+      id: account.id || uuid(),
+      ...account,
+    })
     this.node.wallet.scanTransactions()
     return importedAccount.serialize()
   }


### PR DESCRIPTION
Fixes issue caused by importing account without an ID. This would cause the SDK to throw when it tries to `Array.slice` `account.id`.